### PR TITLE
Fix links to example authentication and lint according to Grafana Labs' style

### DIFF
--- a/docs/sources/setup/authentication.md
+++ b/docs/sources/setup/authentication.md
@@ -108,7 +108,7 @@ OAuth 2.0 JWT require the following parameters
 
 ## Azure
 
-If you want to authenticate your API endpoints via Microsoft Azure authentication, refer to [Axure authentication](/docs/plugins/yesoreyeram-infinity-datasource/latest/examples/azure/).
+If you want to authenticate your API endpoints via Microsoft Azure authentication, refer to [Azure authentication](/docs/plugins/yesoreyeram-infinity-datasource/latest/examples/azure/).
 
 ## Azure Blob Storage key
 

--- a/docs/sources/setup/authentication.md
+++ b/docs/sources/setup/authentication.md
@@ -26,90 +26,97 @@ weight: 231
 
 # Authentication
 
-Infinity datasource supports following authentication methods
+Infinity data source supports following authentication methods
 
-- No Authentication
+- No authentication
 - Basic authentication
 - Bearer token authentication
-- API Key authentication
+- API key authentication
 - Digest authentication
 - OAuth passthrough
-- OAuth2 client credentials
-- OAuth2 JWT authentication
+- OAuth 2.0 client credentials
+- OAuth 2.0 JWT authentication
 - Azure authentication
 - Azure blob storage key
 - AWS authentication
 
-## No Authentication
+## No authentication
 
-If your APIs doesn't require any authentication, select **No Authentication** method.
+If your APIs don't require any authentication, select the **No Authentication** method.
 
-## Basic Authentication
+## Basic
 
-Basic authentication sends a username and password with your request. In the request Headers, the Authorization header will be sent in the `Basic <Base64 encoded username and password>` format.
+Basic authentication sends a username and password with your request.
+In the request headers, the `Authorization` header uses the `Basic <BASE64_ENCODED_USERNAME_AND_PASSWORD>` format.
 
-## Bearer Token Authentication
+## Bearer token
 
-Bearer token enable requests to authenticate using an access key, such as a JSON Web Token (JWT), personal access token. In the request Headers, the Authorization header will be sent in the `Bearer <Your API key>` format.
+Bearer token enable requests to authenticate using an access key, such as a JSON Web Token (JWT), personal access token.
+In the request headers, the `Authorization` header uses the `Bearer <API_KEY>` format.
 
-> If you need a custom prefix instead of Bearer prefix, use API Key authentication instead with the key of **Authorization**.
+{{< admonition type="tip" >}}
+If you need a custom prefix instead of `Bearer` prefix, use API key authentication instead with the key of `Authorization`.
+{{< /admonition >}}
 
-## API Key Authentication
+## API key
 
-With API key authentication, you can send a key-value pair to the API via request header or query parameter. API Key authentication requires following parameters
+With API key authentication, you can send a key-value pair to the API via request headers or query parameters.
+API key authentication requires following parameters:
 
-| Key   | Description                                                                                                                                                                |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Key   | Key of the API token. This wll be key of the header or query parameter.                                                                                                    |
-| Value | Value of the API token                                                                                                                                                     |
-| In    | Accepts `header`/`query`. Most APIs accept API keys via headers which is preferred way of sending api keys. Sending API keys via the query parameter is not suggested way. |
+| Key       | Description                                                                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Key**   | Key of the API token. This becomes the key of the header or query parameter.                                                                         |
+| **Value** | Value of the API token                                                                                                                               |
+| **In**    | Accepts `header`/`query`. Most APIs accept API keys via headers as a preferred way of sending API keys. Sending API keys via the query parameter is. |
 
-> Most often, users got confused with API key authentication with bearer token authentication. So just double check, you are using the correct auth mechanism.
+{{< admonition type="tip" >}}
+It's easy to confuse API key authentication with bearer token authentication, make sure you are using the correct authentication mechanism.
+{{< /admonition >}}
 
-## Digest Authentication
+## Digest
 
 Digest authentication enable requests to authenticate using [RFC7616 HTTP Digest Access Authentication protocol](https://www.rfc-editor.org/rfc/rfc7616.txt).
 
-## OAuth Passthrough
+## OAuth passthrough
 
-If grafana user is already authenticated via OAuth, this authentication method will forward the oauth tokens to the API.
+If your Grafana user is already authenticated via OAuth, this authentication method forwards the OAuth tokens to the API.
 
-## OAuth2 Client Credentials Authentication
+## OAuth 2.0 client credentials
 
-OAuth2 Client credentials require the following parameters
+OAuth 2.0 client credentials require the following parameters:
 
-| Key             | Description                                                                                       |
-| --------------- | ------------------------------------------------------------------------------------------------- |
-| Client ID       | ClientID is the application's ID                                                                  |
-| Client Secret   | ClientSecret is the application's secret.                                                         |
-| Token URL       | TokenURL is the resource server's token endpoint URL. This is a constant specific to each server. |
-| Scopes          | Scope specifies optional requested permissions.                                                   |
-| Endpoint params | EndpointParams specifies additional parameters for requests to the token endpoint.                |
+| Key                 | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| **Client ID**       | ClientID is the application's ID                                                                  |
+| **Client Secret**   | ClientSecret is the application's secret.                                                         |
+| **Token URL**       | TokenURL is the resource server's token endpoint URL. This is a constant specific to each server. |
+| **Scopes**          | Scope specifies optional requested permissions.                                                   |
+| **Endpoint params** | EndpointParams specifies additional parameters for requests to the token endpoint.                |
 
-## OAuth2 JWT Authentication
+## OAuth 2.0 JWT
 
-OAuth2 JWT require the following parameters
+OAuth 2.0 JWT require the following parameters
 
-| Key                    | Description                                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Email                  | Email is the OAuth client identifier used when communicating with the configured OAuth provider                 |
-| Private Key            | PrivateKey contains the contents of an RSA private key or the contents of a PEM file that contains a privatekey |
-| Private Key Identifier | Optional. PrivateKeyID contains an optional hint indicating which key is being used                             |
-| Token URL              | TokenURL is the endpoint required to complete the 2-legged JWT flow                                             |
-| Subject                | Optional. Subject is the optional user to impersonate                                                           |
-| Scopes                 | Scopes optionally specifies a list of requested permission scopes. Provide scopes as a comma separated values   |
+| Key                        | Description                                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Email**                  | Email is the OAuth client identifier used when communicating with the configured OAuth provider.                  |
+| **Private Key**            | PrivateKey contains the contents of an RSA private key or the contents of a PEM file that contains a private key. |
+| **Private Key Identifier** | Optional. PrivateKeyID contains an optional hint indicating which key to use.                                     |
+| **Token URL**              | TokenURL is the endpoint required to complete the 2-legged JWT flow.                                              |
+| **Subject**                | Optional. Subject is the optional user to impersonate.                                                            |
+| **Scopes**                 | Scopes optionally specifies a list of requested permission scopes. Provide scopes as a comma separated values.    |
 
-## Azure Authentication
+## Azure
 
-If you want to authenticate your API endpoints via microsoft azure authentication, refer steps given [here](/docs/azure-authentication).
+If you want to authenticate your API endpoints via Microsoft Azure authentication, refer to [Axure authentication](/docs/plugins/yesoreyeram-infinity-datasource/latest/examples/azure/).
 
 ## Azure Blob Storage key
 
 To retrieve content from azure blob storage, you need to provide the following information
 
 - Azure storage account name
-- Azure storage account key ( either primary key or secondary key)
+- Azure storage account key (either primary key or secondary key)
 
-## AWS Authentication
+## AWS
 
-If you want to authenticate your API endpoints via amazon aws authentication, refer steps given [here](/docs/aws-authentication).
+If you want to authenticate your API endpoints via Amazon AWS authentication, refer to [AWS authentication](/docs/plugins/yesoreyeram-infinity-datasource/latest/examples/aws/).

--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -1,2 +1,2 @@
 # List of projects to provide to the make-docs script.
-PROJECTS = plugins/yesoreyeram-infinity-datasource
+PROJECTS := plugins/yesoreyeram-infinity-datasource


### PR DESCRIPTION
Style is defined in https://grafana.com/docs/writers-toolkit/.

Happy to answer any questions regarding the style changes.

Broken links were reported in https://grafana.slack.com/archives/CNCRV74GP/p1706429377929869.