### PR TITLE
column editor fixes 

### DIFF
--- a/.changeset/friendly-months-tell.md
+++ b/.changeset/friendly-months-tell.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fixed a bug where query columns editor is unusable when sanbox enabled

--- a/src/components/QueryColumnItem.tsx
+++ b/src/components/QueryColumnItem.tsx
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import React, { useState } from 'react';
 import { isDataQuery, isBackendQuery } from './../app/utils';
 import { INFINITY_COLUMN_FORMATS } from './../constants';
@@ -20,22 +19,22 @@ export const QueryColumnItem = (props: QueryColumnItemProps) => {
     return <></>;
   }
   const onSelectorChange = () => {
-    const columns = cloneDeep(query.columns || []);
+    let columns = [...(query.columns || [])];
     columns[index].selector = selector;
     onChange({ ...query, columns });
   };
   const onTextChange = () => {
-    const columns = cloneDeep(query.columns || []);
+    let columns = [...(query.columns || [])];
     columns[index].text = text;
     onChange({ ...query, columns });
   };
   const onTimeFormatChange = (timestampFormat: string) => {
-    const columns = cloneDeep(query.columns || []);
+    let columns = [...(query.columns || [])];
     columns[index].timestampFormat = timestampFormat;
     onChange({ ...query, columns });
   };
   const onFormatChange = (type: InfinityColumnFormat) => {
-    const columns = cloneDeep(query.columns || []);
+    let columns = [...(query.columns || [])];
     columns[index].type = type;
     onChange({ ...query, columns });
   };

--- a/src/editors/query/query.columns.editor.tsx
+++ b/src/editors/query/query.columns.editor.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Button, TextArea } from '@grafana/ui';
-import { cloneDeep } from 'lodash';
 import { EditorRow } from './../../components/extended/EditorRow';
 import { EditorField } from './../../components/extended/EditorField';
 import { Stack } from './../../components/extended/Stack';
@@ -19,16 +18,12 @@ export const QueryColumnsEditor = (props: { query: InfinityQuery; onChange: (val
     return <></>;
   }
   const onColumnAdd = () => {
-    const columns = cloneDeep(query.columns || []);
-    const defaultColumn = {
-      text: '',
-      selector: '',
-      type: 'string',
-    };
+    let columns = [...(query.columns || [])];
+    const defaultColumn = { text: '', selector: '', type: 'string' };
     onChange({ ...query, columns: [...columns, defaultColumn] });
   };
   const onColumnRemove = (index: number) => {
-    const columns = cloneDeep(query.columns || []);
+    let columns = [...(query.columns || [])];
     columns.splice(index, 1);
     onChange({ ...query, columns });
   };


### PR DESCRIPTION
When the frontend sandbox enabled, query columns editor fields we not updating. They clear themselves on blur.

### How to test

* clone the repo main branch and build ( `yarn && yarn build && mage -v` ). ( make sure node version is 18. )
* add/update the following files to enable the sandbox

```yaml
# docker-compose.yaml
version: '3.7'

services:
  grafana:
    container_name: yesoreyeram-infinity-datasource
    platform: linux/amd64
    image: grafana/grafana-dev:10.2.0-130706pre
    ports:
      - 3000:3000/tcp
    volumes:
      - ./dist:/var/lib/grafana/plugins/yesoreyeram-infinity-datasource
      - ./custom.ini:/etc/grafana/grafana.ini
    environment:
```

```ini
# custom.ini
app_mode = development

[security]
frontend_sandbox_disable_for_plugins =

[feature_toggles]
pluginsFrontendSandbox = true
```
* `docker compose up`
* Edit the default query and update the columns to see the behaviour
* `docker compose down`
* Switch to the branch,
* `yarn build`
* `docker compose up`
* See the old buggy behaviour should be fixed.

related internal discussion : https://raintank-corp.slack.com/archives/C05L7NUVBK6/p1706635017508529