### PR TITLE
updated rudderstack events

### DIFF
--- a/.changeset/brown-clocks-remember.md
+++ b/.changeset/brown-clocks-remember.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+Updated health check messages to include details about custom health check settings

--- a/.changeset/friendly-months-tell.md
+++ b/.changeset/friendly-months-tell.md
@@ -2,4 +2,4 @@
 'grafana-infinity-datasource': patch
 ---
 
-Fixed a bug where query columns editor is unusable when sanbox enabled
+Fixed a bug where query columns editor is unusable when sandbox enabled

--- a/.changeset/late-hats-breathe.md
+++ b/.changeset/late-hats-breathe.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Updated rudderstack analytics events

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -108,6 +108,7 @@
     "popperjs",
     "prismjs",
     "promhttp",
+    "rudderstack",
     "scroller",
     "seriesgen",
     "sigv",

--- a/docs/sources/setup/configuration.md
+++ b/docs/sources/setup/configuration.md
@@ -45,6 +45,12 @@ This datasource can work out of the box without any additional configuration. If
 
 More details about the URL and related settings can be found in [url](/docs/url) page
 
+## Health check
+
+When you save the infinity datasource settings in the config page, By default this will just save the settings and won't perform any validation against any URLs. If you want to validate the settings such as authentication, api keys, then you must enable custom health check in the health check section of the configuration page.
+
+> Currently only HTTP GET methods are supported in the custom health check. Also custom health checks only validate the response status code HTTP 200 and doesn't perform any validation against the response content
+
 ## Proxy outgoing requests
 
 If you want your datasource to connect via proxy, set the environment appropriate environment variables. HTTP_PROXY, HTTPS_PROXY and NO_PROXY. HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.

--- a/src/datasource.spec.ts
+++ b/src/datasource.spec.ts
@@ -75,9 +75,28 @@ describe('metricFindQuery', () => {
 
 describe('testDatasource', () => {
   beforeEach(() => jest.spyOn(DataSourceWithBackend.prototype, 'testDatasource').mockResolvedValue({ message: 'OK' }));
-  it('should not throw error when allowed hosts configured', async () => {
+  it('should pass with the default settings', async () => {
+    const ds = new Datasource({ ...DummyDatasource });
+    const result = await ds.testDatasource();
+    expect(result).toStrictEqual({
+      status: 'success',
+      message: 'OK. Settings saved',
+    });
+  });
+  it('should warn when no health check configured', async () => {
     const ds = new Datasource({ ...DummyDatasource, jsonData: { auth_method: 'apiKey', allowedHosts: ['foo'] } });
     const result = await ds.testDatasource();
-    expect(result).toStrictEqual({ status: 'success', message: 'OK. Settings saved' });
+    expect(result).toStrictEqual({
+      status: 'warning',
+      message: 'Success. Settings saved but no health checks performed. To validate the connection/credentials, you have to provide a sample URL in Health Check section',
+    });
+  });
+  it('should pass when health check and allowed hosts configured', async () => {
+    const ds = new Datasource({ ...DummyDatasource, jsonData: { auth_method: 'apiKey', allowedHosts: ['foo'], customHealthCheckEnabled: true, customHealthCheckUrl: 'https://foo.com' } });
+    const result = await ds.testDatasource();
+    expect(result).toStrictEqual({
+      status: 'success',
+      message: 'OK. Settings saved',
+    });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,5 +1,5 @@
 import { LoadingState, toDataFrame, DataFrame, DataQueryRequest, DataQueryResponse, ScopedVars, TimeRange } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, HealthStatus } from '@grafana/runtime';
 import { flatten, sample } from 'lodash';
 import { Observable } from 'rxjs';
 import { applyGroq } from './app/GROQProvider';
@@ -25,7 +25,7 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
   query(options: DataQueryRequest<InfinityQuery>): Observable<DataQueryResponse> {
     return new Observable<DataQueryResponse>((subscriber) => {
       let request = getUpdatedDataRequest(options, this.instanceSettings);
-      reportQuery(request?.targets || [], this.instanceSettings, request?.app);
+      reportQuery(request?.targets || [], this.instanceSettings, this.meta, request?.app);
       super
         .query(request)
         .toPromise()
@@ -98,17 +98,16 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
     return super
       .testDatasource()
       .then((o) => {
+        reportHealthCheck(o, this.instanceSettings, this.meta);
         switch (o?.message) {
           case 'OK':
-            reportHealthCheck({ status: 'success', message: 'OK. Settings saved', authMethod: this.instanceSettings?.jsonData?.auth_method || '' });
             return Promise.resolve({ status: 'success', message: 'OK. Settings saved' });
           default:
-            reportHealthCheck({ status: o?.status || 'success', message: o?.message || 'Settings saved' });
             return Promise.resolve({ status: o?.status || 'success', message: o?.message || 'Settings saved' });
         }
       })
       .catch((ex) => {
-        reportHealthCheck({ status: 'error', message: ex.message });
+        reportHealthCheck({ status: HealthStatus.Error, message: ex }, this.instanceSettings, this.meta);
         return Promise.resolve({ status: 'error', message: ex.message });
       });
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -101,6 +101,14 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
         reportHealthCheck(o, this.instanceSettings, this.meta);
         switch (o?.message) {
           case 'OK':
+            if (!(this.instanceSettings?.jsonData?.customHealthCheckEnabled && this.instanceSettings?.jsonData?.customHealthCheckUrl) && this.instanceSettings?.jsonData?.auth_method) {
+              const healthCheckMessage = [
+                'Success',
+                'Settings saved but no health checks performed',
+                'To validate the connection/credentials, you have to provide a sample URL in Health Check section',
+              ].join(`. `);
+              return Promise.resolve({ status: 'warning', message: healthCheckMessage });
+            }
             return Promise.resolve({ status: 'success', message: 'OK. Settings saved' });
           default:
             return Promise.resolve({ status: o?.status || 'success', message: o?.message || 'Settings saved' });

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,62 +1,78 @@
-import { CoreApp } from '@grafana/data';
-import { reportInteraction, config } from '@grafana/runtime';
+import { CoreApp, DataSourcePluginMeta } from '@grafana/data';
+import { reportInteraction, config, HealthCheckResult } from '@grafana/runtime';
 import { isBackendQuery } from './../app/utils';
 import { InfinityInstanceSettings, InfinityQuery } from './../types';
 
 type Report_Action = 'grafana_infinity_query_executed' | 'grafana_infinity_health_check_executed';
 
-const reportActivity = (action: Report_Action, meta?: Record<string, any>) => {
+const reportActivity = (action: Report_Action, data: Record<string, any> = {}, instance_settings?: InfinityInstanceSettings, plugin_meta?: DataSourcePluginMeta) => {
   try {
-    reportInteraction(action, { ...meta, plugin_name: 'yesoreyeram-infinity-datasource', ts: new Date().getTime() });
+    // Grafana related meta
+    data['grafana_licenseInfo_stateInfo'] = config?.licenseInfo?.stateInfo || '';
+    data['grafana_buildInfo_edition'] = config?.buildInfo?.edition || '';
+    data['grafana_buildInfo_version'] = config?.buildInfo?.version || '';
+    data['grafana_buildInfo_version_short'] = (config?.buildInfo?.version || '').split('-')[0];
+    data['grafana_app_url'] = config?.appUrl || '';
+    const grafana_url = new URL(window?.document?.URL);
+    data['grafana_host'] = grafana_url?.host || grafana_url?.hostname || 'unknown';
+    // Plugin meta
+    data['plugin_id'] = plugin_meta?.id || 'yesoreyeram-infinity-datasource';
+    data['plugin_version'] = plugin_meta?.info?.version || 'unknown';
+    // Plugin configuration
+    data['config_authType'] = instance_settings?.jsonData?.auth_method || instance_settings?.jsonData?.authType || 'unknown';
+    data['config_oauth2_type'] = instance_settings?.jsonData?.oauth2?.oauth2_type || 'unknown';
+    data['config_global_queries_count'] = (instance_settings?.jsonData?.global_queries || []).length;
+    data['config_reference_data_count'] = (instance_settings?.jsonData?.refData || []).length;
+    data['config_allowed_hosts_count'] = (instance_settings?.jsonData.allowedHosts || []).length;
+    reportInteraction(action, { ...data, ts: new Date().getTime() });
   } catch (ex) {
     console.error('error while reporting infinity query', ex);
   }
 };
 
-export const reportHealthCheck = (meta: Record<string, string> = {}) => {
-  reportActivity('grafana_infinity_health_check_executed', meta);
+export const reportHealthCheck = (o?: Omit<HealthCheckResult, 'details'>, instance_settings?: InfinityInstanceSettings, plugin_meta?: DataSourcePluginMeta) => {
+  let meta: Record<string, any> = {
+    plugin_healthcheck_status: o?.status || 'unknown',
+    plugin_healthcheck_message: o?.message || 'unknown',
+  };
+  reportActivity('grafana_infinity_health_check_executed', meta, instance_settings, plugin_meta);
 };
 
-export const reportQuery = (queries: InfinityQuery[] = [], instance_settings?: InfinityInstanceSettings, app = 'unknown') => {
+export const reportQuery = (queries: InfinityQuery[] = [], instance_settings?: InfinityInstanceSettings, plugin_meta?: DataSourcePluginMeta, app = 'unknown') => {
   if (app === CoreApp.Dashboard || app === CoreApp.PanelViewer) {
     return;
   }
-  let input: Record<string, number | string> = {};
+  let meta: Record<string, number | string> = {};
   for (const query of queries) {
-    input['grafana_buildInfo_edition'] = config?.buildInfo?.edition || '';
-    input['grafana_buildInfo_version'] = config?.buildInfo?.version || '';
-    input['grafana_licenseInfo_stateInfo'] = config?.licenseInfo?.stateInfo || '';
-    if (instance_settings) {
-      input['config_authType'] = instance_settings.jsonData?.authType || 'unknown';
-      input['config_oauth2_type'] = instance_settings.jsonData?.oauth2?.oauth2_type || 'unknown';
-    }
-    input['query_type'] = query.type;
-    input['query_source'] = (query as any).source || 'unknown';
-    input['query_parser'] = (query as any).parser || 'unknown';
+    meta['grafana_app'] = app;
+    meta['query_type'] = (query as any).type || 'unknown';
+    meta['query_source'] = (query as any).source || 'unknown';
+    meta['query_parser'] = (query as any).parser || 'unknown';
+    meta['query_format'] = (query as any).format || 'unknown';
     const queryUrl = (query as any).url || '';
     if (queryUrl) {
       try {
         const baseUrl = new URL(queryUrl);
-        input['query_url_host'] = baseUrl.host || baseUrl.hostname;
-        input['query_url_path'] = baseUrl.pathname;
+        meta['query_url_host'] = baseUrl.host || baseUrl.hostname;
       } catch (ex) {
         console.error(ex);
       }
     }
     if (isBackendQuery(query)) {
       if (query.summarizeExpression) {
-        input['query_summarizeExpression'] = 'in_use';
+        meta['query_summarizeExpression'] = 'in_use';
       }
       if (query.summarizeBy) {
-        input['query_summarizeBy'] = 'in_use';
+        meta['query_summarizeBy'] = 'in_use';
       }
       if (query.filterExpression) {
-        input['query_filterExpression'] = 'in_use';
+        meta['query_filterExpression'] = 'in_use';
       }
       if (query.computed_columns && query.computed_columns.length > 0) {
-        input['query_computed_columns'] = query.computed_columns.length;
+        meta['query_computed_columns'] = query.computed_columns.length;
       }
+      meta['query_pagination_mode'] = query.pagination_mode || 'none';
     }
-    reportActivity('grafana_infinity_query_executed', input);
+    reportActivity('grafana_infinity_query_executed', meta, instance_settings, plugin_meta);
   }
 };

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -23,7 +23,8 @@ const reportActivity = (action: Report_Action, data: Record<string, any> = {}, i
     data['config_oauth2_type'] = instance_settings?.jsonData?.oauth2?.oauth2_type || 'unknown';
     data['config_global_queries_count'] = (instance_settings?.jsonData?.global_queries || []).length;
     data['config_reference_data_count'] = (instance_settings?.jsonData?.refData || []).length;
-    data['config_allowed_hosts_count'] = (instance_settings?.jsonData.allowedHosts || []).length;
+    data['config_allowed_hosts_count'] = (instance_settings?.jsonData?.allowedHosts || []).length;
+    data['config_custom_health_check_enabled'] = instance_settings?.jsonData?.customHealthCheckEnabled ? 'enabled' : 'unknown';
     reportInteraction(action, { ...data, ts: new Date().getTime() });
   } catch (ex) {
     console.error('error while reporting infinity query', ex);


### PR DESCRIPTION
This PR allows to pass additional meta data when used with rudder stack analytics.

I couln't find an easy way to validate this unless you have some rudderstack instances.(but also you can add some ugly console logging is fine as well )