### PR TITLE
updated health check warning

### DIFF
--- a/.changeset/brown-clocks-remember.md
+++ b/.changeset/brown-clocks-remember.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+Updated health check messages to include details about custom health check settings

--- a/docs/sources/setup/configuration.md
+++ b/docs/sources/setup/configuration.md
@@ -45,6 +45,12 @@ This datasource can work out of the box without any additional configuration. If
 
 More details about the URL and related settings can be found in [url](/docs/url) page
 
+## Health check
+
+When you save the infinity datasource settings in the config page, By default this will just save the settings and won't perform any validation against any URLs. If you want to validate the settings such as authentication, api keys, then you must enable custom health check in the health check section of the configuration page.
+
+> Currently only HTTP GET methods are supported in the custom health check. Also custom health checks only validate the response status code HTTP 200 and doesn't perform any validation against the response content
+
 ## Proxy outgoing requests
 
 If you want your datasource to connect via proxy, set the environment appropriate environment variables. HTTP_PROXY, HTTPS_PROXY and NO_PROXY. HTTPS_PROXY takes precedence over HTTP_PROXY for https requests.

--- a/src/datasource.spec.ts
+++ b/src/datasource.spec.ts
@@ -75,9 +75,28 @@ describe('metricFindQuery', () => {
 
 describe('testDatasource', () => {
   beforeEach(() => jest.spyOn(DataSourceWithBackend.prototype, 'testDatasource').mockResolvedValue({ message: 'OK' }));
-  it('should not throw error when allowed hosts configured', async () => {
+  it('should pass with the default settings', async () => {
+    const ds = new Datasource({ ...DummyDatasource });
+    const result = await ds.testDatasource();
+    expect(result).toStrictEqual({
+      status: 'success',
+      message: 'OK. Settings saved',
+    });
+  });
+  it('should warn when no health check configured', async () => {
     const ds = new Datasource({ ...DummyDatasource, jsonData: { auth_method: 'apiKey', allowedHosts: ['foo'] } });
     const result = await ds.testDatasource();
-    expect(result).toStrictEqual({ status: 'success', message: 'OK. Settings saved' });
+    expect(result).toStrictEqual({
+      status: 'warning',
+      message: 'Success. Settings saved but no health checks performed. To validate the connection/credentials, you have to provide a sample URL in Health Check section',
+    });
+  });
+  it('should pass when health check and allowed hosts configured', async () => {
+    const ds = new Datasource({ ...DummyDatasource, jsonData: { auth_method: 'apiKey', allowedHosts: ['foo'], customHealthCheckEnabled: true, customHealthCheckUrl: 'https://foo.com' } });
+    const result = await ds.testDatasource();
+    expect(result).toStrictEqual({
+      status: 'success',
+      message: 'OK. Settings saved',
+    });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -101,6 +101,14 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
         reportHealthCheck(o, this.instanceSettings, this.meta);
         switch (o?.message) {
           case 'OK':
+            if (!(this.instanceSettings?.jsonData?.customHealthCheckEnabled && this.instanceSettings?.jsonData?.customHealthCheckUrl) && this.instanceSettings?.jsonData?.auth_method) {
+              const healthCheckMessage = [
+                'Success',
+                'Settings saved but no health checks performed',
+                'To validate the connection/credentials, you have to provide a sample URL in Health Check section',
+              ].join(`. `);
+              return Promise.resolve({ status: 'warning', message: healthCheckMessage });
+            }
             return Promise.resolve({ status: 'success', message: 'OK. Settings saved' });
           default:
             return Promise.resolve({ status: o?.status || 'success', message: o?.message || 'Settings saved' });

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -23,7 +23,8 @@ const reportActivity = (action: Report_Action, data: Record<string, any> = {}, i
     data['config_oauth2_type'] = instance_settings?.jsonData?.oauth2?.oauth2_type || 'unknown';
     data['config_global_queries_count'] = (instance_settings?.jsonData?.global_queries || []).length;
     data['config_reference_data_count'] = (instance_settings?.jsonData?.refData || []).length;
-    data['config_allowed_hosts_count'] = (instance_settings?.jsonData.allowedHosts || []).length;
+    data['config_allowed_hosts_count'] = (instance_settings?.jsonData?.allowedHosts || []).length;
+    data['config_custom_health_check_enabled'] = instance_settings?.jsonData?.customHealthCheckEnabled ? 'enabled' : 'unknown';
     reportInteraction(action, { ...data, ts: new Date().getTime() });
   } catch (ex) {
     console.error('error while reporting infinity query', ex);


### PR DESCRIPTION
Currently if a user save the infinity datasource, it will just save the settings but won't perform any healthcheck against any URL. From 2.0.0 version, custom health check was introduced but it is not very obvious to the user that this feature exist. This also leads to instances such as configuration page succeeded but query failed due to incorrect authentication. 

So this PR adds some addition context to the health check success messages reminding the user to configure custom health check if required.

## Steps to validate

* create a new infinity instance
* Save and test -> success `OK. Settings saved`
* Go to authentication. Enable basic auth ( username : foo , password : foo (incorrect password) )
* Save and test -> error `invalid settings. configure allowed hosts in the authentication section`
* Add `https://httpbin.org` as allowed host in the auth/security section
* Save and test -> warning `Success. Settings saved but no health checks performed. To validate the connection/credentials, you have to provide a sample URL in Health Check section`
* Visit **Health check** section and enable 
* Save and test -> warning `Success. Settings saved but no health checks performed. To validate the connection/credentials, you have to provide a sample URL in Health Check section`
* Add health check URL `https://httpbin.org/basic-auth/foo/bar`
* Save and test -> error `health check failed with url https://httpbin.org/basic-auth/foo/bar. error received: 401 UNAUTHORIZED` due to incorrect password
* Change password in the auth section to `bar`
* Save and test -> success `health check successful with url https://httpbin.org/basic-auth/foo/bar. http status code received: 200`

## Default - no customization / no authentication 

<img width="972" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/90b90950-531f-4232-90b3-79f3a8e1730c">

## Basic auth with custom health check

<img width="944" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/5cd4e807-6fcb-46f3-9c24-e51c0375e580">

<img width="1084" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/20fde1ba-88bb-4afa-bc1e-a5671fddda0b">

## Basic auth without custom health check

<img width="1291" alt="image" src="https://github.com/grafana/grafana-infinity-datasource/assets/153843/743327fa-41bd-431a-ab5a-73417e2267e2">
