### PR TITLE
AWS +PDC fix

### DIFF
--- a/.changeset/shy-tools-heal.md
+++ b/.changeset/shy-tools-heal.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fixed a bug where AWS authentication doesn't work since 2.5.0-beta.1

--- a/pkg/infinity/client.go
+++ b/pkg/infinity/client.go
@@ -155,6 +155,9 @@ func NewClient(ctx context.Context, settings models.InfinitySettings) (client *C
 }
 
 func ApplySecureSocksProxyConfiguration(httpClient *http.Client, settings models.InfinitySettings) (*http.Client, error) {
+	if IsAwsAuthConfigured(settings) {
+		return httpClient, nil
+	}
 	t := httpClient.Transport
 	if IsDigestAuthConfigured(settings) {
 		// if we are using Digest, the Transport is 'digest.Transport' that wraps 'http.Transport'

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -130,6 +130,15 @@ func (s *InfinitySettings) Validate() error {
 		}
 		return nil
 	}
+	if s.AuthenticationMethod == AuthenticationMethodAWS && s.AWSSettings.AuthType == AWSAuthTypeKeys {
+		if strings.TrimSpace(s.AWSAccessKey) == "" {
+			return errors.New("invalid/empty AWS access key")
+		}
+		if strings.TrimSpace(s.AWSSecretKey) == "" {
+			return errors.New("invalid/empty AWS secret key")
+		}
+		return nil
+	}
 	if s.AuthenticationMethod != AuthenticationMethodNone && len(s.AllowedHosts) < 1 {
 		return errors.New("configure allowed hosts in the authentication section")
 	}


### PR DESCRIPTION
Since the introduction of PDC in 2.5.0-beta.1, AWS authentication stopped working due to a panic. This PR skips PDC part if the auth type selected is AWS

### How to test

```go
package testsuite_test

import (
	"context"
	"testing"

	"github.com/grafana/grafana-infinity-datasource/pkg/pluginhost"
	"github.com/grafana/grafana-plugin-sdk-go/backend"
	"github.com/stretchr/testify/require"
)

func TestAWSAuth(t *testing.T) {
	host := pluginhost.NewDatasource()
	require.NotNil(t, host)
	res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
		PluginContext: backend.PluginContext{
			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
				JSONData: []byte(`{
					"allowedHosts": [ "https://monitoring.us-east-2.amazonaws.com" ],
					"auth_method": "aws"
				}`),
				DecryptedSecureJSONData: map[string]string{
					"awsAccessKey": `xxxxxx`,
					"awsSecretKey": `xxxxxx`,
				},
			},
		},
		Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(`{
			"type"		:	"json",
			"source"	:	"url",
			"url" 		: 	"https://monitoring.us-east-2.amazonaws.com?Action=ListMetrics"
		}`)}},
	})
	require.Nil(t, err)
	require.NotNil(t, res)
	require.Nil(t, res.Responses["A"].Error)
}
```

without the fix, you will see the following error

```sh
--- FAIL: TestAWSAuth (0.00s)
panic: interface conversion: http.RoundTripper is sigv4.RoundTripperFunc, not *http.Transport [recovered]
	panic: interface conversion: http.RoundTripper is sigv4.RoundTripperFunc, not *http.Transport

goroutine 50 [running]:
testing.tRunner.func1.2({0x10dbd7840, 0xc00078c390})
	/usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1634 +0x377
panic({0x10dbd7840?, 0xc00078c390?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/grafana/grafana-infinity-datasource/pkg/infinity.ApplySecureSocksProxyConfiguration(_, {{0x0, 0x0}, {0x0, 0x0}, 0x0, {0xc000807597, 0x3}, {{0x0, 0x0}, ...}, ...})
	/Users/sriram/Documents/grafana/dev/plugins/oss/infinity/pkg/infinity/client.go:171 +0x370```
