### PR TITLE
managed datasource instance migration

### DIFF
--- a/.changeset/new-taxis-glow.md
+++ b/.changeset/new-taxis-glow.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+⚙️ **Chore**: backend datasource.serve method migrated to datasource.manage method

--- a/pkg/infinity/postprocess.go
+++ b/pkg/infinity/postprocess.go
@@ -39,11 +39,6 @@ func PostProcessFrame(ctx context.Context, frame *data.Frame, query models.Query
 		return transformations.GetSummaryFrame(frame, query.SummarizeExpression, query.SummarizeBy, alias)
 	}
 	frame.Meta = &data.FrameMeta{Custom: &CustomMeta{Query: query}}
-	if err != nil {
-		backend.Logger.Error("error getting response for query", "error", err.Error())
-		frame.Meta.Custom = &CustomMeta{Query: query, Error: err.Error()}
-		return frame, err
-	}
 	if query.Source == "inline" {
 		frame, err = WrapMetaForInlineQuery(ctx, frame, err, query)
 		if err != nil {

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -13,10 +13,10 @@ import (
 const pluginID = "yesoreyeram-infinity-datasource"
 
 func main() {
-	if err := backend.SetupTracer(pluginID, tracing.Opts{}); err != nil {
-		backend.Logger.Error("error setting up tracer", "error", err.Error())
+	dsOptions := datasource.ManageOpts{
+		TracingOpts: tracing.Opts{},
 	}
-	if err := datasource.Serve(pluginhost.NewDatasource()); err != nil {
+	if err := datasource.Manage(pluginID, pluginhost.NewDataSourceInstance, dsOptions); err != nil {
 		backend.Logger.Error("error starting infinity plugin", "error", err.Error())
 		os.Exit(1)
 	}

--- a/pkg/pluginhost/handler_checkhealth.go
+++ b/pkg/pluginhost/handler_checkhealth.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/grafana/grafana-infinity-datasource/pkg/infinity"
 	"github.com/grafana/grafana-infinity-datasource/pkg/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 // CheckHealth handles health checks sent from Grafana to the plugin.
-func (ds *PluginHost) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func (ds *DataSource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	logger := backend.Logger.FromContext(ctx)
-	healthCheckResult, err := CheckHealth(ctx, ds, req)
+	healthCheckResult, err := CheckHealth(ctx, ds.client, req)
 	if err != nil {
 		logger.Error("received error while performing health check", "err", err.Error())
 		return &backend.CheckHealthResult{
@@ -23,44 +24,37 @@ func (ds *PluginHost) CheckHealth(ctx context.Context, req *backend.CheckHealthR
 	return healthCheckResult, nil
 }
 
-func CheckHealth(ctx context.Context, ds *PluginHost, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func CheckHealth(ctx context.Context, client *infinity.Client, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	logger := backend.Logger.FromContext(ctx)
-	client, err := getInstance(ctx, ds.im, req.PluginContext)
-	if err != nil {
-		return &backend.CheckHealthResult{
-			Status:  backend.HealthStatusError,
-			Message: fmt.Sprintf("error loading datasource settings. %s", err.Error()),
-		}, nil
-	}
-	if client == nil || client.client == nil {
+	if client == nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
 			Message: "failed to get plugin instance",
 		}, nil
 	}
 	args := []interface{}{}
-	args = append(args, "AuthenticationMethod", client.client.Settings.AuthenticationMethod)
-	if len(client.client.Settings.AllowedHosts) > 0 {
-		args = append(args, "AllowedHosts_0", client.client.Settings.AllowedHosts[0])
+	args = append(args, "AuthenticationMethod", client.Settings.AuthenticationMethod)
+	if len(client.Settings.AllowedHosts) > 0 {
+		args = append(args, "AllowedHosts_0", client.Settings.AllowedHosts[0])
 	}
-	if client.client.Settings.OAuth2Settings.OAuth2Type != "" {
-		args = append(args, "OAuth2Type", client.client.Settings.OAuth2Settings.OAuth2Type)
+	if client.Settings.OAuth2Settings.OAuth2Type != "" {
+		args = append(args, "OAuth2Type", client.Settings.OAuth2Settings.OAuth2Type)
 	}
 	logger.Info("performing CheckHealth in infinity datasource", args...)
-	if err = client.client.Settings.Validate(); err != nil {
+	if err := client.Settings.Validate(); err != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
 			Message: fmt.Sprintf("invalid settings. %s", err.Error()),
 		}, nil
 	}
-	if client.client.Settings.AuthenticationMethod == models.AuthenticationMethodAzureBlob {
+	if client.Settings.AuthenticationMethod == models.AuthenticationMethodAzureBlob {
 		return checkHealthAzureBlobStorage(ctx, client)
 	}
-	if client.client.Settings.CustomHealthCheckEnabled && client.client.Settings.CustomHealthCheckUrl != "" {
-		_, statusCode, _, err := client.client.GetResults(ctx, models.Query{
+	if client.Settings.CustomHealthCheckEnabled && client.Settings.CustomHealthCheckUrl != "" {
+		_, statusCode, _, err := client.GetResults(ctx, models.Query{
 			Type:   models.QueryTypeUQL,
 			Source: "url",
-			URL:    client.client.Settings.CustomHealthCheckUrl,
+			URL:    client.Settings.CustomHealthCheckUrl,
 			URLOptions: models.URLOptions{
 				Method: http.MethodGet,
 			},
@@ -68,19 +62,19 @@ func CheckHealth(ctx context.Context, ds *PluginHost, req *backend.CheckHealthRe
 		if err != nil {
 			return &backend.CheckHealthResult{
 				Status:  backend.HealthStatusError,
-				Message: fmt.Sprintf("health check failed with url %s. error received: %s", client.client.Settings.CustomHealthCheckUrl, err.Error()),
+				Message: fmt.Sprintf("health check failed with url %s. error received: %s", client.Settings.CustomHealthCheckUrl, err.Error()),
 			}, nil
 		}
 		if statusCode != http.StatusOK {
 			return &backend.CheckHealthResult{
 				Status:  backend.HealthStatusError,
-				Message: fmt.Sprintf("health check failed with url %s. http status code received: %d", client.client.Settings.CustomHealthCheckUrl, statusCode),
+				Message: fmt.Sprintf("health check failed with url %s. http status code received: %d", client.Settings.CustomHealthCheckUrl, statusCode),
 			}, nil
 		}
 		if statusCode == http.StatusOK {
 			return &backend.CheckHealthResult{
 				Status:  backend.HealthStatusOk,
-				Message: fmt.Sprintf("health check successful with url %s. http status code received: %d", client.client.Settings.CustomHealthCheckUrl, statusCode),
+				Message: fmt.Sprintf("health check successful with url %s. http status code received: %d", client.Settings.CustomHealthCheckUrl, statusCode),
 			}, nil
 		}
 	}

--- a/pkg/pluginhost/handler_checkhealth_azblob.go
+++ b/pkg/pluginhost/handler_checkhealth_azblob.go
@@ -5,20 +5,15 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
+	"github.com/grafana/grafana-infinity-datasource/pkg/infinity"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func checkHealthAzureBlobStorage(ctx context.Context, client *instanceSettings) (*backend.CheckHealthResult, error) {
+func checkHealthAzureBlobStorage(ctx context.Context, client *infinity.Client) (*backend.CheckHealthResult, error) {
 	if client == nil {
-		return healthCheckError("invalid client")
-	}
-	if client.client == nil {
 		return healthCheckError("invalid infinity client")
 	}
-	if client.client.AzureBlobClient == nil {
-		return healthCheckError("invalid azure blob client")
-	}
-	blobServiceClient := client.client.AzureBlobClient.ServiceClient()
+	blobServiceClient := client.AzureBlobClient.ServiceClient()
 	if blobServiceClient == nil {
 		return healthCheckError("invalid azure blob service client. check storage account name and key")
 	}

--- a/pkg/pluginhost/handler_dispose.go
+++ b/pkg/pluginhost/handler_dispose.go
@@ -1,0 +1,4 @@
+package pluginhost
+
+func (host *DataSource) Dispose() {
+}

--- a/pkg/pluginhost/plugin.go
+++ b/pkg/pluginhost/plugin.go
@@ -2,38 +2,25 @@ package pluginhost
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/grafana/grafana-infinity-datasource/pkg/infinity"
 	"github.com/grafana/grafana-infinity-datasource/pkg/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 )
 
-type PluginHost struct {
-	im instancemgmt.InstanceManager
-}
+var (
+	_ backend.QueryDataHandler      = (*DataSource)(nil)
+	_ backend.CheckHealthHandler    = (*DataSource)(nil)
+	_ backend.CallResourceHandler   = (*DataSource)(nil)
+	_ instancemgmt.InstanceDisposer = (*DataSource)(nil)
+)
 
-func NewDatasource() datasource.ServeOpts {
-	host := &PluginHost{
-		im: datasource.NewInstanceManager(newDataSourceInstance),
-	}
-	return datasource.ServeOpts{
-		QueryDataHandler:    host,
-		CheckHealthHandler:  host,
-		CallResourceHandler: httpadapter.New(host.getRouter()),
-	}
-}
-
-type instanceSettings struct {
+type DataSource struct {
 	client *infinity.Client
 }
 
-func (is *instanceSettings) Dispose() {}
-
-func newDataSourceInstance(ctx context.Context, setting backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+func NewDataSourceInstance(ctx context.Context, setting backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	settings, err := models.LoadSettings(ctx, setting)
 	if err != nil {
 		return nil, err
@@ -43,20 +30,7 @@ func newDataSourceInstance(ctx context.Context, setting backend.DataSourceInstan
 	if err != nil {
 		return nil, err
 	}
-	return &instanceSettings{
+	return &DataSource{
 		client: client,
 	}, nil
-}
-
-func getInstance(ctx context.Context, im instancemgmt.InstanceManager, pCtx backend.PluginContext) (*instanceSettings, error) {
-	instance, err := im.Get(ctx, pCtx)
-	if err != nil {
-		return nil, err
-	}
-	return instance.(*instanceSettings), nil
-}
-
-func getInstanceFromRequest(ctx context.Context, im instancemgmt.InstanceManager, req *http.Request) (*instanceSettings, error) {
-	pCtx := httpadapter.PluginConfigFromContext(req.Context())
-	return getInstance(ctx, im, pCtx)
 }

--- a/pkg/testsuite/handler_querydata_test.go
+++ b/pkg/testsuite/handler_querydata_test.go
@@ -1015,20 +1015,28 @@ func TestRemoteSources(t *testing.T) {
 	}
 }
 
-func TestQuery(t *testing.T) {
-	host := pluginhost.NewDatasource()
+func getds(t *testing.T, settings backend.DataSourceInstanceSettings) *pluginhost.DataSource {
+	t.Helper()
+	host, err := pluginhost.NewDataSourceInstance(context.Background(), settings)
+	require.Nil(t, err)
 	require.NotNil(t, host)
+	ds, ok := host.(*pluginhost.DataSource)
+	require.True(t, ok)
+	require.NotNil(t, ds)
+	return ds
+
+}
+
+func TestQuery(t *testing.T) {
 	t.Run("json default url default", func(t *testing.T) {
 		server := getServerWithStaticResponse(t, `{"message":"ok"}`, false)
 		server.Start()
 		defer server.Close()
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 				"type"		:	"json",
 				"source"	:	"url",
@@ -1044,13 +1052,11 @@ func TestQuery(t *testing.T) {
 		server := getServerWithStaticResponse(t, strings.Join([]string{`name,age`, `foo,123`, `bar,456`}, "\n"), false)
 		server.Start()
 		defer server.Close()
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 				"type"		:	"csv",
 				"source"	:	"url",
@@ -1066,13 +1072,11 @@ func TestQuery(t *testing.T) {
 		server := getServerWithStaticResponse(t, strings.Join([]string{`name,age`, `foo,123`, `bar,456`}, "\n"), false)
 		server.Start()
 		defer server.Close()
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 				"type"		:	"csv",
 				"source"	:	"url",
@@ -1086,13 +1090,11 @@ func TestQuery(t *testing.T) {
 		experimental.CheckGoldenJSONResponse(t, "golden", strings.ReplaceAll(t.Name(), "TestQuery/", ""), &resItem, UPDATE_GOLDEN_DATA)
 	})
 	t.Run("csv backend inline default", func(t *testing.T) {
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte((`{ 
 				"type"		:	"csv",
 				"source"	:	"inline",
@@ -1119,13 +1121,11 @@ func TestQuery(t *testing.T) {
 		</users>`, false)
 		server.Start()
 		defer server.Close()
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 				"type"			:	"xml",
 				"source"		:	"url",
@@ -1143,14 +1143,12 @@ func TestQuery(t *testing.T) {
 		server := getServerWithStaticResponse(t, "../../testdata/users.html", true)
 		server.Start()
 		defer server.Close()
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
 		t.Run("default url default", func(t *testing.T) {
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData:                []byte(`{"is_mock": true}`),
-						DecryptedSecureJSONData: map[string]string{},
-					},
-				},
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 					"type": "html",
 					"url":  "%s",
@@ -1191,13 +1189,11 @@ func TestQuery(t *testing.T) {
 			experimental.CheckGoldenJSONResponse(t, "golden", strings.ReplaceAll(t.Name(), "TestQuery/html/", "html_"), &resItem, UPDATE_GOLDEN_DATA)
 		})
 		t.Run("backend url default", func(t *testing.T) {
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData:                []byte(`{"is_mock": true}`),
-						DecryptedSecureJSONData: map[string]string{},
-					},
-				},
+			ds := getds(t, backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"is_mock": true}`),
+				DecryptedSecureJSONData: map[string]string{},
+			})
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 					"type": "html",
 					"url":  "%s",
@@ -1248,13 +1244,11 @@ func TestQuery(t *testing.T) {
 		server := getServerWithStaticResponse(t, "./../../testdata/misc/azure-cost-management-daily.json", true)
 		server.Start()
 		defer server.Close()
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(fmt.Sprintf(`{ 
 				"type"			: "json",
 				"source"		: "url",
@@ -1282,13 +1276,11 @@ func TestQuery(t *testing.T) {
 		experimental.CheckGoldenJSONResponse(t, "golden", strings.ReplaceAll(t.Name(), "TestQuery/", ""), &resItem, UPDATE_GOLDEN_DATA)
 	})
 	t.Run("transformations limit default", func(t *testing.T) {
-		res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-					JSONData:                []byte(`{"is_mock": true}`),
-					DecryptedSecureJSONData: map[string]string{},
-				},
-			},
+		ds := getds(t, backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{"is_mock": true}`),
+			DecryptedSecureJSONData: map[string]string{},
+		})
+		res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{
 				{
 					RefID: "A",
@@ -1333,20 +1325,18 @@ func TestQuery(t *testing.T) {
 			server := getServerWithStaticResponse(t, "./../../testdata/users.json", true)
 			server.Start()
 			defer server.Close()
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData: []byte(fmt.Sprintf(`{
-							"is_mock"				: true,
-							"auth_method"			: "azureBlob",
-							"azureBlobAccountUrl"	: "%s",
-							"azureBlobAccountName"  : "dummyaccount"
-						}`, server.URL)),
-						DecryptedSecureJSONData: map[string]string{
-							"azureBlobAccountKey": "ZmFrZQ==",
-						},
-					},
+			ds := getds(t, backend.DataSourceInstanceSettings{
+				JSONData: []byte(fmt.Sprintf(`{
+					"is_mock"				: true,
+					"auth_method"			: "azureBlob",
+					"azureBlobAccountUrl"	: "%s",
+					"azureBlobAccountName"  : "dummyaccount"
+				}`, server.URL)),
+				DecryptedSecureJSONData: map[string]string{
+					"azureBlobAccountKey": "ZmFrZQ==",
 				},
+			})
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{
 					{
 						RefID: "A",
@@ -1370,20 +1360,18 @@ func TestQuery(t *testing.T) {
 			server := getServerWithStaticResponse(t, "./../../testdata/users.csv", true)
 			server.Start()
 			defer server.Close()
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData: []byte(fmt.Sprintf(`{
-							"is_mock"				: true,
-							"auth_method"			: "azureBlob",
-							"azureBlobAccountUrl"	: "%s",
-							"azureBlobAccountName"  : "dummyaccount"
-						}`, server.URL)),
-						DecryptedSecureJSONData: map[string]string{
-							"azureBlobAccountKey": "ZmFrZQ==",
-						},
-					},
+			ds := getds(t, backend.DataSourceInstanceSettings{
+				JSONData: []byte(fmt.Sprintf(`{
+					"is_mock"				: true,
+					"auth_method"			: "azureBlob",
+					"azureBlobAccountUrl"	: "%s",
+					"azureBlobAccountName"  : "dummyaccount"
+				}`, server.URL)),
+				DecryptedSecureJSONData: map[string]string{
+					"azureBlobAccountKey": "ZmFrZQ==",
 				},
+			})
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{
 					{
 						RefID: "A",
@@ -1407,20 +1395,18 @@ func TestQuery(t *testing.T) {
 			server := getServerWithStaticResponse(t, "./../../testdata/users.xml", true)
 			server.Start()
 			defer server.Close()
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData: []byte(fmt.Sprintf(`{
-							"is_mock"				: true,
-							"auth_method"			: "azureBlob",
-							"azureBlobAccountUrl"	: "%s",
-							"azureBlobAccountName"  : "dummyaccount"
-						}`, server.URL)),
-						DecryptedSecureJSONData: map[string]string{
-							"azureBlobAccountKey": "ZmFrZQ==",
-						},
-					},
+			ds := getds(t, backend.DataSourceInstanceSettings{
+				JSONData: []byte(fmt.Sprintf(`{
+					"is_mock"				: true,
+					"auth_method"			: "azureBlob",
+					"azureBlobAccountUrl"	: "%s",
+					"azureBlobAccountName"  : "dummyaccount"
+				}`, server.URL)),
+				DecryptedSecureJSONData: map[string]string{
+					"azureBlobAccountKey": "ZmFrZQ==",
 				},
+			})
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{
 					{
 						RefID: "A",
@@ -1444,20 +1430,18 @@ func TestQuery(t *testing.T) {
 			server := getServerWithStaticResponse(t, "./../../testdata/users.tsv", true)
 			server.Start()
 			defer server.Close()
-			res, err := host.QueryData(context.Background(), &backend.QueryDataRequest{
-				PluginContext: backend.PluginContext{
-					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-						JSONData: []byte(fmt.Sprintf(`{
-							"is_mock"				: true,
-							"auth_method"			: "azureBlob",
-							"azureBlobAccountUrl"	: "%s",
-							"azureBlobAccountName"  : "dummyaccount"
-						}`, server.URL)),
-						DecryptedSecureJSONData: map[string]string{
-							"azureBlobAccountKey": "ZmFrZQ==",
-						},
-					},
+			ds := getds(t, backend.DataSourceInstanceSettings{
+				JSONData: []byte(fmt.Sprintf(`{
+					"is_mock"				: true,
+					"auth_method"			: "azureBlob",
+					"azureBlobAccountUrl"	: "%s",
+					"azureBlobAccountName"  : "dummyaccount"
+				}`, server.URL)),
+				DecryptedSecureJSONData: map[string]string{
+					"azureBlobAccountKey": "ZmFrZQ==",
 				},
+			})
+			res, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
 				Queries: []backend.DataQuery{
 					{
 						RefID: "A",


### PR DESCRIPTION
backend datasource.serve method migrated to datasource.manage method.

## How to test

* build the frontend `yarn build`
* build the backend `mage -v`
* spin up the grafana `docker compose up`
* visit localhost:3000
* open the provisioned datasource **Postman Echo - Basic Auth** and perform the health check -This ensure check health code path works as expected
* open the provisioned datasource **Infinity** - Open the explore and run query.
* change to backend parser - should produce the results
* change the source to "reference data"  and select "users.csv", change the type to "csv" - should produce the results. This ensure the resource calls and query path works as expected.
