### PR TITLE
fix incorrect label name of detail__*

### DIFF
--- a/src/app/parsers/InfinityParser.ts
+++ b/src/app/parsers/InfinityParser.ts
@@ -78,7 +78,7 @@ export class InfinityParser<T extends InfinityQuery> {
           } else if (field.name.startsWith('detail__')) {
             field.config = {
               ...field.config,
-              displayName: field.values.get(0),
+              displayName: field.name.replace('detail__', ''),
             };
           }
           return field;


### PR DESCRIPTION
currently, set `config.displayName` with value of first column. but we expect to use the suffix of `detail__*`