### PR TITLE
release prep 2.9.0

### DIFF
--- a/.changeset/famous-apricots-begin.md
+++ b/.changeset/famous-apricots-begin.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-Replaced backend framer libraries from [yesoreyeram/grafana-plugins](https://github.com/yesoreyeram/grafana-plugins) to [grafana/infinity-libs](https://github.com/grafana/infinity-libs)

--- a/.changeset/happy-chairs-lie.md
+++ b/.changeset/happy-chairs-lie.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-Updated uql library to [0.0.23](https://github.com/yesoreyeram/uql/blob/main/CHANGELOG.md#0023)

--- a/.changeset/light-balloons-buy.md
+++ b/.changeset/light-balloons-buy.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-Add error source to error responses

--- a/.changeset/rude-seahorses-invite.md
+++ b/.changeset/rude-seahorses-invite.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-⚙️ **Chore**: Upgrade grafana-plugin-sdk-go to `v0.239.0` from `v0.231.0`

--- a/.changeset/tidy-moose-tell.md
+++ b/.changeset/tidy-moose-tell.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-Fix showing of correct URL when using query history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.9.0
 
-🚀 **UQL**:Updated uql library to [0.0.23](https://github.com/yesoreyeram/uql/blob/main/CHANGELOG.md#0023)
+🚀 **UQL**: Updated uql library to [0.0.23](https://github.com/yesoreyeram/uql/blob/main/CHANGELOG.md#0023)
 
 🚀 **Chore** Replaced backend framer libraries from [yesoreyeram/grafana-plugins](https://github.com/yesoreyeram/grafana-plugins) to [grafana/infinity-libs](https://github.com/grafana/infinity-libs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Change Log
 
+## 2.9.0
+
+🚀 **UQL**:Updated uql library to [0.0.23](https://github.com/yesoreyeram/uql/blob/main/CHANGELOG.md#0023)
+
+🚀 **Chore** Replaced backend framer libraries from [yesoreyeram/grafana-plugins](https://github.com/yesoreyeram/grafana-plugins) to [grafana/infinity-libs](https://github.com/grafana/infinity-libs)
+
+⚙️ **Chore**: Add error source to error responses
+
+⚙️ **Chore**: Upgrade grafana-plugin-sdk-go to `v0.239.0` from `v0.231.0`
+
+🐛 **Bug fix**: Fix showing of correct URL when using query history
+
 ## 2.8.0
 
 ⚙️ **Chore**: backend datasource.serve method migrated to datasource.manage method
 
 🐛 **Bug fix**: Fixed a bug where filters not working in variables editor
-
 
 ## 2.7.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-infinity-datasource",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "JSON, CSV, XML, GraphQL, HTML and REST API datasource for Grafana. Do infinite things with Grafana. Transform data with UQL/GROQ. Visualize data from many apis, RSS/ATOM feeds directly",
   "keywords": [
     "grafana",


### PR DESCRIPTION
release prep 2.9.0


## 2.9.0

🚀 **UQL**:Updated uql library to [0.0.23](https://github.com/yesoreyeram/uql/blob/main/CHANGELOG.md#0023)

🚀 **Chore** Replaced backend framer libraries from [yesoreyeram/grafana-plugins](https://github.com/yesoreyeram/grafana-plugins) to [grafana/infinity-libs](https://github.com/grafana/infinity-libs)

⚙️ **Chore**: Add error source to error responses

⚙️ **Chore**: Upgrade grafana-plugin-sdk-go to `v0.239.0` from `v0.231.0`

🐛 **Bug fix**: Fix showing of correct URL when using query history