### PR TITLE
Query cancellation: Correctly cancel queries

### DIFF
--- a/.changeset/sharp-crews-try.md
+++ b/.changeset/sharp-crews-try.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix query cancellation

--- a/pkg/infinity/request.go
+++ b/pkg/infinity/request.go
@@ -22,9 +22,9 @@ func GetRequest(ctx context.Context, settings models.InfinitySettings, body io.R
 	}
 	switch strings.ToUpper(query.URLOptions.Method) {
 	case http.MethodPost:
-		req, err = http.NewRequest(http.MethodPost, url, body)
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	default:
-		req, err = http.NewRequest(http.MethodGet, url, nil)
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	}
 	req = ApplyAcceptHeader(query, settings, req, includeSect)
 	req = ApplyContentTypeHeader(query, settings, req, includeSect)

--- a/pkg/pluginhost/handler_querydata.go
+++ b/pkg/pluginhost/handler_querydata.go
@@ -138,7 +138,7 @@ func QueryDataQuery(ctx context.Context, query models.Query, infClient infinity.
 			}
 			frame, err := infinity.GetFrameForURLSources(ctx, query, infClient, requestHeaders)
 			if err != nil {
-				logger.Error("error while performing the infinity query", "msg", err.Error())
+				logger.Debug("error while performing the infinity query", "msg", err.Error())
 				if frame != nil {
 					frame, _ = infinity.WrapMetaForRemoteQuery(ctx, infClient.Settings, frame, err, query)
 					response.Frames = append(response.Frames, frame)


### PR DESCRIPTION
Cancelling a query does not stop its execution due to missing `NewRequestWithContext`.

**Testing:**
- You can use following url to run query https://fakestoreapi.com/products?limit=5000.  Make sure that you cancel as fast as possible as it might execute quite fast
1. Check logs/metrics for `status=cancelled` (previously  `status=ok`)
1. If you want, you can use debugger and observe that the query is now cancelled (previously it continued to run)

**Fix:**
Query cancellation now works correctly by using `NewRequestWithContext`. See attached logs for confirmation:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/28c6ceaf-a727-43e4-bdd5-cc5513260fe0">

I have also lowered the levels of logged "errors", as we were getting error logs also for context.canceled. Switching to debug to reduce noise. 