### PR TITLE
Fix error source for invalid JSONata

### DIFF
--- a/.changeset/small-queens-shake.md
+++ b/.changeset/small-queens-shake.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix error source for invalid JSONata errors

--- a/pkg/infinity/inline.go
+++ b/pkg/infinity/inline.go
@@ -3,9 +3,11 @@ package infinity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana-infinity-datasource/pkg/models"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/infinity-libs/lib/go/jsonframer"
 )
 
@@ -46,6 +48,9 @@ func GetFrameForInlineSources(ctx context.Context, query models.Query) (*data.Fr
 			Columns:      columns,
 		})
 		if err != nil {
+			if errors.Is(err, jsonframer.ErrInvalidRootSelector) || errors.Is(err, jsonframer.ErrInvalidJSONContent) || errors.Is(err, jsonframer.ErrEvaluatingJSONata) {
+			return frame, errorsource.DownstreamError(fmt.Errorf("error converting json data to frame: %w", err), false)
+		}
 			return frame, err
 		}
 		if newFrame != nil {

--- a/pkg/infinity/jsonBackend.go
+++ b/pkg/infinity/jsonBackend.go
@@ -41,7 +41,7 @@ func GetJSONBackendResponse(ctx context.Context, urlResponseObject any, query mo
 	})
 
 	if err != nil {
-		if errors.Is(err, jsonframer.ErrInvalidRootSelector) || errors.Is(err, jsonframer.ErrInvalidJSONContent) || errors.Is(err, jsonframer.ErrInvalidJSONContent) {
+		if errors.Is(err, jsonframer.ErrInvalidRootSelector) || errors.Is(err, jsonframer.ErrInvalidJSONContent) || errors.Is(err, jsonframer.ErrEvaluatingJSONata) {
 			return frame, errorsource.DownstreamError(fmt.Errorf("error converting json data to frame: %w", err), false)
 		}
 		return frame, errorsource.PluginError(fmt.Errorf("error converting json data to frame: %w", err), false)


### PR DESCRIPTION
This PR does 2 things:

1. It fixes error source when `URL` source is selected and there is `ErrEvaluatingJSONata` error. In code, there was a typo, where instead of checking for `ErrEvaluatingJSONata` , we were checking `ErrInvalidJSONContent` twice. Here is the list of all these 3 errors to check: https://github.com/grafana/infinity-libs/blob/c9bd79b3ed2330cc16dcdf818b05dbc42b8355c2/lib/go/jsonframer/errors.go#L7

2. When using `Inline` source, there was missing the same check as we have in `URL` for these errors after using `jsonframer.ToFrame`. Here we are adding it. 


Fixed: 

<img width="1503" alt="image" src="https://github.com/user-attachments/assets/8a935ff4-c01c-4024-96d6-27491c681380">


Broken (before):
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/a577b236-a3aa-4b6a-834c-d2db35b8a401">
