### PR TITLE
Add dependabot to update sdk

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      # Keep the experimental modules up-to-date
+      - dependency-name: "github.com/grafana/grafana-plugin-sdk-go"
+        dependency-type: "all"
+    commit-message:
+      prefix: "Upgrade grafana-plugin-sdk-go "
+      include: "scope"
+    reviewers:
+      - "grafana/oss-big-tent"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      # Keep the experimental modules up-to-date
+      # Keep the sdk modules up-to-date
       - dependency-name: "github.com/grafana/grafana-plugin-sdk-go"
         dependency-type: "all"
     commit-message:


### PR DESCRIPTION
This PR adds Dependabot config to check for sdk module updates weekly and create PRs to upgrade them. This is a routine task that can be automated to avoid human error.

