### PR TITLE
Remove deprecation for base URL

### DIFF
--- a/.changeset/gorgeous-laws-hunt.md
+++ b/.changeset/gorgeous-laws-hunt.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+Remove base URL deprecation

--- a/docs/sources/references/url.md
+++ b/docs/sources/references/url.md
@@ -28,8 +28,6 @@ You can enter any URL in the query URL field. URL must be a valid JSON, CSV, Gra
 
 In the query editor, click the expand icon next the URL field to configure more query URL options like HTTP Method (GET/POST), additional headers and additional query strings.
 
-**Leave the URL in the datasource configuration blank.** URL in the datasource config is now deprecated. Use URL in the query editor instead.
-
 ## Variables in URL
 
 In the query URL, you can use any [grafana global variables](https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables) or any dashboard variables this includes from and to timestamps of the dashboard

--- a/src/editors/config.editor.tsx
+++ b/src/editors/config.editor.tsx
@@ -19,7 +19,11 @@ import { QueryParamEditor } from './config/QueryParamEditor';
 
 const Collapse = CollapseOriginal as any;
 
-export const MainEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOptions> & { setActiveTab: React.Dispatch<React.SetStateAction<string>> }) => {
+export const MainEditor = (
+  props: DataSourcePluginOptionsEditorProps<InfinityOptions> & {
+    setActiveTab: React.Dispatch<React.SetStateAction<string>>;
+  }
+) => {
   const { setActiveTab, options } = props;
   const theme = useTheme2();
   return (
@@ -36,10 +40,18 @@ export const MainEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOpt
     >
       <h1>👋 Welcome to Grafana Infinity Data Source!</h1>
       <p style={{ marginBlockStart: 5 }}>
-        <b>Without any additional configuration, this datasource can work.</b> Optionally, configure any of the settings you see in the left side such as Authentication if you needed.
+        <b>Without any additional configuration, this datasource can work.</b> Optionally, configure any of the settings
+        you see in the left side such as Authentication if you needed.
       </p>
       <div style={{ marginBlockStart: 5 }}>
-        <Button icon="lock" variant="primary" fill="outline" size="md" onClick={() => setActiveTab('auth')} style={{ marginInlineEnd: '5px', color: theme.isDark ? '#d9d9d9' : '' }}>
+        <Button
+          icon="lock"
+          variant="primary"
+          fill="outline"
+          size="md"
+          onClick={() => setActiveTab('auth')}
+          style={{ marginInlineEnd: '5px', color: theme.isDark ? '#d9d9d9' : '' }}
+        >
           Setup Authentication
         </Button>
         <LinkButton
@@ -74,11 +86,28 @@ export const HeadersEditor = (props: DataSourcePluginOptionsEditorProps<Infinity
   const { options, onOptionsChange } = props;
   return (
     <>
+      <Collapse isOpen={true} collapsible={true} label="Base URL">
+        <URLEditor options={options} onOptionsChange={onOptionsChange} />
+      </Collapse>
       <Collapse isOpen={true} collapsible={true} label="Custom HTTP Headers">
-        <SecureFieldsEditor dataSourceConfig={options} onChange={onOptionsChange} title="Custom HTTP Header" secureFieldName="httpHeaderName" secureFieldValue="httpHeaderValue" hideTile={true} />
+        <SecureFieldsEditor
+          dataSourceConfig={options}
+          onChange={onOptionsChange}
+          title="Custom HTTP Header"
+          secureFieldName="httpHeaderName"
+          secureFieldValue="httpHeaderValue"
+          hideTile={true}
+        />
       </Collapse>
       <Collapse isOpen={true} collapsible={true} label="URL Query Param">
-        <SecureFieldsEditor dataSourceConfig={options} onChange={onOptionsChange} title="URL Query Param" secureFieldName="secureQueryName" secureFieldValue="secureQueryValue" hideTile={true} />
+        <SecureFieldsEditor
+          dataSourceConfig={options}
+          onChange={onOptionsChange}
+          title="URL Query Param"
+          secureFieldName="secureQueryName"
+          secureFieldValue="secureQueryValue"
+          hideTile={true}
+        />
       </Collapse>
       <Collapse isOpen={true} collapsible={true} label="Query Param Encoding (EXPERIMENTAL)">
         <QueryParamEditor options={options} onOptionsChange={onOptionsChange} />
@@ -126,25 +155,15 @@ export const SecurityEditor = (props: DataSourcePluginOptionsEditorProps<Infinit
   );
 };
 
-export const MiscEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {
-  const { options, onOptionsChange } = props;
-  return (
-    <>
-      <URLEditor options={options} onOptionsChange={onOptionsChange} />
-    </>
-  );
-};
-
 const config_sections: Array<{ value: string; label: string }> = [
   { value: 'main', label: 'Main' },
   { value: 'auth', label: 'Authentication' },
-  { value: 'headers_and_params', label: 'Headers & URL params' },
+  { value: 'headers_and_params', label: 'URL, Headers & Params' },
   { value: 'network', label: 'Network' },
   { value: 'security', label: 'Security' },
   { value: 'health_check', label: 'Health check' },
   { value: 'reference_data', label: 'Reference data' },
   { value: 'global_queries', label: 'Global queries' },
-  { value: 'misc', label: 'Misc' },
 ];
 
 export const InfinityConfigEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {
@@ -204,7 +223,11 @@ export const InfinityConfigEditor = (props: DataSourcePluginOptionsEditorProps<I
       <div className={styles.root}>
         <div className={styles.tabs}>
           {config_sections.map((tab) => (
-            <div key={tab.value} className={activeTab === tab.value ? styles.tab_active : styles.tab} onClick={() => setActiveTab(tab.value)}>
+            <div
+              key={tab.value}
+              className={activeTab === tab.value ? styles.tab_active : styles.tab}
+              onClick={() => setActiveTab(tab.value)}
+            >
               {tab.label}
             </div>
           ))}
@@ -226,8 +249,6 @@ export const InfinityConfigEditor = (props: DataSourcePluginOptionsEditorProps<I
             <ReferenceDataEditor options={options} onOptionsChange={onOptionsChange} />
           ) : activeTab === 'health_check' ? (
             <CustomHealthCheckEditor options={options} onOptionsChange={onOptionsChange} />
-          ) : activeTab === 'misc' ? (
-            <MiscEditor options={options} onOptionsChange={onOptionsChange} />
           ) : (
             <AuthEditor options={options} onOptionsChange={onOptionsChange} />
           )}

--- a/src/editors/config.editor.tsx
+++ b/src/editors/config.editor.tsx
@@ -40,18 +40,10 @@ export const MainEditor = (
     >
       <h1>👋 Welcome to Grafana Infinity Data Source!</h1>
       <p style={{ marginBlockStart: 5 }}>
-        <b>Without any additional configuration, this datasource can work.</b> Optionally, configure any of the settings
-        you see in the left side such as Authentication if you needed.
+        <b>Without any additional configuration, this datasource can work.</b> Optionally, configure any of the settings you see in the left side such as Authentication if you needed.
       </p>
       <div style={{ marginBlockStart: 5 }}>
-        <Button
-          icon="lock"
-          variant="primary"
-          fill="outline"
-          size="md"
-          onClick={() => setActiveTab('auth')}
-          style={{ marginInlineEnd: '5px', color: theme.isDark ? '#d9d9d9' : '' }}
-        >
+        <Button icon="lock" variant="primary" fill="outline" size="md" onClick={() => setActiveTab('auth')} style={{ marginInlineEnd: '5px', color: theme.isDark ? '#d9d9d9' : '' }}>
           Setup Authentication
         </Button>
         <LinkButton
@@ -90,24 +82,10 @@ export const HeadersEditor = (props: DataSourcePluginOptionsEditorProps<Infinity
         <URLEditor options={options} onOptionsChange={onOptionsChange} />
       </Collapse>
       <Collapse isOpen={true} collapsible={true} label="Custom HTTP Headers">
-        <SecureFieldsEditor
-          dataSourceConfig={options}
-          onChange={onOptionsChange}
-          title="Custom HTTP Header"
-          secureFieldName="httpHeaderName"
-          secureFieldValue="httpHeaderValue"
-          hideTile={true}
-        />
+        <SecureFieldsEditor dataSourceConfig={options} onChange={onOptionsChange} title="Custom HTTP Header" secureFieldName="httpHeaderName" secureFieldValue="httpHeaderValue" hideTile={true} />
       </Collapse>
       <Collapse isOpen={true} collapsible={true} label="URL Query Param">
-        <SecureFieldsEditor
-          dataSourceConfig={options}
-          onChange={onOptionsChange}
-          title="URL Query Param"
-          secureFieldName="secureQueryName"
-          secureFieldValue="secureQueryValue"
-          hideTile={true}
-        />
+        <SecureFieldsEditor dataSourceConfig={options} onChange={onOptionsChange} title="URL Query Param" secureFieldName="secureQueryName" secureFieldValue="secureQueryValue" hideTile={true} />
       </Collapse>
       <Collapse isOpen={true} collapsible={true} label="Query Param Encoding (EXPERIMENTAL)">
         <QueryParamEditor options={options} onOptionsChange={onOptionsChange} />
@@ -223,11 +201,7 @@ export const InfinityConfigEditor = (props: DataSourcePluginOptionsEditorProps<I
       <div className={styles.root}>
         <div className={styles.tabs}>
           {config_sections.map((tab) => (
-            <div
-              key={tab.value}
-              className={activeTab === tab.value ? styles.tab_active : styles.tab}
-              onClick={() => setActiveTab(tab.value)}
-            >
+            <div key={tab.value} className={activeTab === tab.value ? styles.tab_active : styles.tab} onClick={() => setActiveTab(tab.value)}>
               {tab.label}
             </div>
           ))}

--- a/src/editors/config/URL.tsx
+++ b/src/editors/config/URL.tsx
@@ -12,10 +12,7 @@ export const URLEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOpti
   };
   return (
     <div className="gf-form">
-      <InlineLabel
-        tooltip="Base URL of the query. Leave blank if you want to handle it in the query editor."
-        width={20}
-      >
+      <InlineLabel tooltip="Base URL of the query. Leave blank if you want to handle it in the query editor." width={20}>
         Base URL
       </InlineLabel>
       <Input

--- a/src/editors/config/URL.tsx
+++ b/src/editors/config/URL.tsx
@@ -1,4 +1,4 @@
-import { Badge, InlineLabel, Input } from '@grafana/ui';
+import { InlineLabel, Input } from '@grafana/ui';
 import React, { useState } from 'react';
 import { IGNORE_URL } from './../../constants';
 import type { InfinityOptions } from './../../types';
@@ -12,7 +12,10 @@ export const URLEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOpti
   };
   return (
     <div className="gf-form">
-      <InlineLabel tooltip="Base URL of the query. Leave blank if you want to handle it in the query editor." width={20}>
+      <InlineLabel
+        tooltip="Base URL of the query. Leave blank if you want to handle it in the query editor."
+        width={20}
+      >
         Base URL
       </InlineLabel>
       <Input
@@ -22,9 +25,6 @@ export const URLEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOpti
         onChange={(e) => setUrl(e.currentTarget.value || '')}
         onBlur={onURLChange}
       />
-      <div style={{ marginInlineStart: '5px' }}>
-        <Badge text="Deprecated field. Use full URL in the query editor instead." color="blue" className="gf-form-label text-info" />
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/11887#issuecomment-2334304657

This PR:
- removes base URL deprecation
- Moves base URL to `Headers & URL params` section and renames it to `URL, Headers & Params`
- Removes deprecation from docs
- Removes now empty `Misc` section

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/eda20e5c-0891-4493-b7d0-b3639a0cfb0c">
