### PR TITLE
Update dompurify to version 2.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "watch": "yarn dev"
   },
   "resolutions": {
-    "dompurify": "2.4.9"
+    "dompurify": "2.5.4"
   },
   "dependencies": {
     "@emotion/css": "11.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4535,10 +4535,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@2.4.9, dompurify@^2.4.3:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.9.tgz#9ccdd9e1780653156b09de873f5372bc1eaf2c40"
-  integrity sha512-iHtnxYMotKgOTvxIqq677JsKHvCOkAFqj9x8Mek2zdeHW1XjuFKwjpmZeMaXQRQ8AbJZDbcRz/+r1QhwvFtmQg==
+dompurify@2.5.4, dompurify@^2.4.3:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.4.tgz#347e91070963b22db31c7c8d0ce9a0a2c3c08746"
+  integrity sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
This pull request includes an update to a dependency version in the `package.json` file.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L52-R52): Updated the `dompurify` library from version `2.4.9` to `2.5.4` to ensure the latest security patches and features are included.