### PR TITLE
Fix `X-Id-Token` auth header forwarding

### DIFF
--- a/.changeset/great-paws-marry.md
+++ b/.changeset/great-paws-marry.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix forward oauth for x-id-token header

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -21,8 +21,8 @@ const (
 const (
 	headerKeyAccept        = "Accept"
 	headerKeyContentType   = "Content-Type"
-	headerKeyAuthorization = "Authorization"
-	headerKeyIdToken       = "X-Id-Token"
+	HeaderKeyAuthorization = "Authorization"
+	HeaderKeyIdToken       = "X-Id-Token"
 )
 
 func ApplyAcceptHeader(query models.Query, settings models.InfinitySettings, req *http.Request, includeSect bool) *http.Request {
@@ -103,7 +103,7 @@ func ApplyBasicAuth(settings models.InfinitySettings, req *http.Request, include
 		if includeSect {
 			basicAuthHeader = "Basic " + base64.StdEncoding.EncodeToString([]byte(settings.UserName+":"+settings.Password))
 		}
-		req.Header.Set(headerKeyAuthorization, basicAuthHeader)
+		req.Header.Set(HeaderKeyAuthorization, basicAuthHeader)
 	}
 	return req
 }
@@ -114,7 +114,7 @@ func ApplyBearerToken(settings models.InfinitySettings, req *http.Request, inclu
 		if includeSect {
 			bearerAuthHeader = fmt.Sprintf("Bearer %s", settings.BearerToken)
 		}
-		req.Header.Add(headerKeyAuthorization, bearerAuthHeader)
+		req.Header.Add(HeaderKeyAuthorization, bearerAuthHeader)
 	}
 	return req
 }
@@ -137,22 +137,20 @@ func ApplyForwardedOAuthIdentity(requestHeaders map[string]string, settings mode
 		authHeader := dummyHeader
 		token := dummyHeader
 		if includeSect {
-			authHeader = getQueryReqHeader(requestHeaders, headerKeyAuthorization)
-			token = getQueryReqHeader(requestHeaders, headerKeyIdToken)
+			authHeader = getQueryReqHeader(requestHeaders, HeaderKeyAuthorization)
+			token = getQueryReqHeader(requestHeaders, HeaderKeyIdToken)
 		}
-		req.Header.Add(headerKeyAuthorization, authHeader)
-		if requestHeaders[headerKeyIdToken] != "" {
-			req.Header.Add(headerKeyIdToken, token)
+		req.Header.Add(HeaderKeyAuthorization, authHeader)
+		if token != "" {
+			req.Header.Add(HeaderKeyIdToken, token)
 		}
 	}
 	return req
 }
 
 func getQueryReqHeader(requestHeaders map[string]string, headerName string) string {
-	headerNameCI := strings.ToLower(headerName)
-
 	for name, value := range requestHeaders {
-		if strings.ToLower(name) == headerNameCI {
+		if strings.EqualFold(headerName, name) {
 			return value
 		}
 	}

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -22,7 +22,7 @@ const (
 	headerKeyAccept        = "Accept"
 	headerKeyContentType   = "Content-Type"
 	headerKeyAuthorization = "Authorization"
-	headerKeyIdToken       = "X-ID-Token"
+	headerKeyIdToken       = "X-Id-Token"
 )
 
 func ApplyAcceptHeader(query models.Query, settings models.InfinitySettings, req *http.Request, includeSect bool) *http.Request {
@@ -137,8 +137,8 @@ func ApplyForwardedOAuthIdentity(requestHeaders map[string]string, settings mode
 		authHeader := dummyHeader
 		token := dummyHeader
 		if includeSect {
-			authHeader = requestHeaders[headerKeyAuthorization]
-			token = requestHeaders[headerKeyIdToken]
+			authHeader = getQueryReqHeader(requestHeaders, headerKeyAuthorization)
+			token = getQueryReqHeader(requestHeaders, headerKeyIdToken)
 		}
 		req.Header.Add(headerKeyAuthorization, authHeader)
 		if requestHeaders[headerKeyIdToken] != "" {
@@ -146,4 +146,17 @@ func ApplyForwardedOAuthIdentity(requestHeaders map[string]string, settings mode
 		}
 	}
 	return req
+}
+
+
+func getQueryReqHeader(requestHeaders map[string]string, headerName string) string {
+	headerNameCI := strings.ToLower(headerName)
+
+	for name, value := range requestHeaders {
+		if strings.ToLower(name) == headerNameCI {
+			return value
+		}
+	}
+
+	return ""
 }

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -141,7 +141,7 @@ func ApplyForwardedOAuthIdentity(requestHeaders map[string]string, settings mode
 			token = getQueryReqHeader(requestHeaders, HeaderKeyIdToken)
 		}
 		req.Header.Add(HeaderKeyAuthorization, authHeader)
-		if token != "" {
+		if token != "" && token != dummyHeader {
 			req.Header.Add(HeaderKeyIdToken, token)
 		}
 	}

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -148,7 +148,6 @@ func ApplyForwardedOAuthIdentity(requestHeaders map[string]string, settings mode
 	return req
 }
 
-
 func getQueryReqHeader(requestHeaders map[string]string, headerName string) string {
 	headerNameCI := strings.ToLower(headerName)
 

--- a/pkg/infinity/headers_test.go
+++ b/pkg/infinity/headers_test.go
@@ -1,0 +1,65 @@
+package infinity
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetQueryReqHeader(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestHeaders map[string]string
+		headerName     string
+		expected       string
+	}{
+		{
+			name: "Authorization header exact match",
+			requestHeaders: map[string]string{
+				headerKeyAuthorization: "Bearer token",
+			},
+			headerName: headerKeyAuthorization,
+			expected:   "Bearer token",
+		},
+		{
+			name: "Authorization header case insensitive match",
+			requestHeaders: map[string]string{
+				strings.ToLower(headerKeyAuthorization): "Bearer token",
+			},
+			headerName: headerKeyAuthorization,
+			expected:   "Bearer token",
+		},
+		{
+			name: "X-Id-Token header exact match",
+			requestHeaders: map[string]string{
+				headerKeyIdToken: "some-id-token",
+			},
+			headerName: headerKeyIdToken,
+			expected:   "some-id-token",
+		},
+		{
+			name: "X-Id-Token header case insensitive match",
+			requestHeaders: map[string]string{
+				strings.ToLower(headerKeyIdToken): "some-id-token",
+			},
+			headerName: headerKeyIdToken,
+			expected:   "some-id-token",
+		},
+		{
+			name: "X-Id-Token header case with ID capitalization",
+			requestHeaders: map[string]string{
+				"X-ID-Token": "some-id-token",
+			},
+			headerName: headerKeyIdToken,
+			expected:   "some-id-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getQueryReqHeader(tt.requestHeaders, tt.headerName)
+			if got != tt.expected {
+				t.Errorf("getQueryReqHeader() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/infinity/headers_test.go
+++ b/pkg/infinity/headers_test.go
@@ -15,33 +15,33 @@ func TestGetQueryReqHeader(t *testing.T) {
 		{
 			name: "Authorization header exact match",
 			requestHeaders: map[string]string{
-				headerKeyAuthorization: "Bearer token",
+				HeaderKeyAuthorization: "Bearer token",
 			},
-			headerName: headerKeyAuthorization,
+			headerName: HeaderKeyAuthorization,
 			expected:   "Bearer token",
 		},
 		{
 			name: "Authorization header case insensitive match",
 			requestHeaders: map[string]string{
-				strings.ToLower(headerKeyAuthorization): "Bearer token",
+				strings.ToLower(HeaderKeyAuthorization): "Bearer token",
 			},
-			headerName: headerKeyAuthorization,
+			headerName: HeaderKeyAuthorization,
 			expected:   "Bearer token",
 		},
 		{
 			name: "X-Id-Token header exact match",
 			requestHeaders: map[string]string{
-				headerKeyIdToken: "some-id-token",
+				HeaderKeyIdToken: "some-id-token",
 			},
-			headerName: headerKeyIdToken,
+			headerName: HeaderKeyIdToken,
 			expected:   "some-id-token",
 		},
 		{
 			name: "X-Id-Token header case insensitive match",
 			requestHeaders: map[string]string{
-				strings.ToLower(headerKeyIdToken): "some-id-token",
+				strings.ToLower(HeaderKeyIdToken): "some-id-token",
 			},
-			headerName: headerKeyIdToken,
+			headerName: HeaderKeyIdToken,
 			expected:   "some-id-token",
 		},
 		{
@@ -49,7 +49,7 @@ func TestGetQueryReqHeader(t *testing.T) {
 			requestHeaders: map[string]string{
 				"X-ID-Token": "some-id-token",
 			},
-			headerName: headerKeyIdToken,
+			headerName: HeaderKeyIdToken,
 			expected:   "some-id-token",
 		},
 	}

--- a/pkg/infinity/meta.go
+++ b/pkg/infinity/meta.go
@@ -139,7 +139,7 @@ func ApplyNotices(ctx context.Context, settings models.InfinitySettings, frame *
 func GetSecureHeaderWarnings(query models.Query) []data.Notice {
 	notices := []data.Notice{}
 	for _, h := range query.URLOptions.Headers {
-		if strings.EqualFold(h.Key, headerKeyAuthorization) {
+		if strings.EqualFold(h.Key, HeaderKeyAuthorization) {
 			notices = append(notices, data.Notice{
 				Severity: data.NoticeSeverityWarning,
 				Text:     fmt.Sprintf("for security reasons, don't include headers such as %s in the query. Instead, add them in the config where possible", h.Key),

--- a/pkg/testsuite/handler_querydata_test.go
+++ b/pkg/testsuite/handler_querydata_test.go
@@ -45,8 +45,8 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should set basic auth headers when set the username and password", func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("infinityUser:myPassword")), r.Header.Get("Authorization"))
-				assert.Equal(t, "", r.Header.Get("X-ID-Token"))
+				assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("infinityUser:myPassword")), r.Header.Get(infinity.HeaderKeyAuthorization))
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyIdToken))
 				fmt.Fprintf(w, `{ "message" : "OK" }`)
 			}))
 			defer server.Close()
@@ -76,8 +76,8 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should return error when incorrect credentials set", func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "", r.Header.Get("X-ID-Token"))
-				if r.Header.Get("Authorization") == "Basic "+base64.StdEncoding.EncodeToString([]byte("infinityUser:myPassword")) {
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyIdToken))
+				if r.Header.Get(infinity.HeaderKeyAuthorization) == "Basic "+base64.StdEncoding.EncodeToString([]byte("infinityUser:myPassword")) {
 					fmt.Fprintf(w, "OK")
 					return
 				}
@@ -113,8 +113,8 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should forward the oauth headers when forward oauth identity is set", func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "foo", r.Header.Get("Authorization"))
-				assert.Equal(t, "bar", r.Header.Get("X-ID-Token"))
+				assert.Equal(t, "foo", r.Header.Get(infinity.HeaderKeyAuthorization))
+				assert.Equal(t, "bar", r.Header.Get(infinity.HeaderKeyIdToken))
 				fmt.Fprintf(w, `{ "message" : "OK" }`)
 			}))
 			defer server.Close()
@@ -137,8 +137,8 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should not forward the oauth headers when forward oauth identity is not set", func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "", r.Header.Get("Authorization"))
-				assert.Equal(t, "", r.Header.Get("X-ID-Token"))
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyAuthorization))
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyIdToken))
 				fmt.Fprintf(w, `{ "message" : "OK" }`)
 			}))
 			defer server.Close()
@@ -207,7 +207,7 @@ func TestAuthentication(t *testing.T) {
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-				if r.Header.Get("Authorization") != "Bearer foo" {
+				if r.Header.Get(infinity.HeaderKeyAuthorization) != "Bearer foo" {
 					w.WriteHeader(http.StatusUnauthorized)
 					return
 				}
@@ -249,7 +249,7 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should error when CA cert verification failed", func(t *testing.T) {
 			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "", r.Header.Get("X-ID-Token"))
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyIdToken))
 				fmt.Fprintf(w, `{ "message" : "OK" }`)
 			}))
 			server.TLS = getServerCertificate(server.URL)
@@ -281,7 +281,7 @@ func TestAuthentication(t *testing.T) {
 		t.Run("should honour skip tls verify setting", func(t *testing.T) {
 			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
-				assert.Equal(t, "", r.Header.Get("X-ID-Token"))
+				assert.Equal(t, "", r.Header.Get(infinity.HeaderKeyIdToken))
 				fmt.Fprintf(w, `{ "message" : "OK" }`)
 			}))
 			server.TLS = getServerCertificate(server.URL)


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/12471

We have recently [changed X-Id-Token header](https://github.com/grafana/grafana/pull/90892) from `X-ID-Token` to `X-Id-Token` and infinity was relying on the exact `X-ID-Token` value. This PR makes the check more robust, and checks for case insensitive form of header. This is the same function as in https://github.com/grafana/grafana-azure-sdk-go/blob/dc5d2b54c53f5ad1d8210508dfecf1775bd7fa1a/azusercontext/from_req.go#L67. 

More context in https://raintank-corp.slack.com/archives/C04CHPYT954/p1727793584704099

Fixed functionality:

https://github.com/user-attachments/assets/d7dc5458-789e-44bd-a62e-dcc77e31802a

