### PR TITLE
chore: Bump jsonpath-plus to version 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "groq-js": "1.1.8",
     "json-to-pretty-yaml": "^1.2.2",
     "jsonata": "2.0.4",
-    "jsonpath-plus": "7.2.0",
+    "jsonpath-plus": "10.0.1",
     "lodash": "^4.17.21",
     "mathjs": "11.7.0",
     "react": "18.2.0",

--- a/src/app/parsers/JSONParser.ts
+++ b/src/app/parsers/JSONParser.ts
@@ -56,7 +56,7 @@ export class JSONParser extends InfinityParser<InfinityJSONQuery | InfinityGraph
           JSONPath({
             path: rootSelect,
             json: JSONResponse,
-            preventEval: true,
+            eval: false,
           })
         );
       } else {

--- a/src/editors/query/query.url.test.tsx
+++ b/src/editors/query/query.url.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { URL } from './query.url';
 import { screen, render } from '@testing-library/react';
-import { InfinityQuery } from 'types';
+import { InfinityQueryType, InfinityQueryWithURLSource } from 'types';
 
 describe('URL', () => {
   it('should show changed URL', () => {
@@ -9,7 +9,7 @@ describe('URL', () => {
       url: 'https://example1.com',
       type: 'json',
       source: 'url',
-    } as InfinityQuery;
+    } as InfinityQueryWithURLSource<InfinityQueryType>;
 
     const props = {
       query: mockQuery1,
@@ -25,7 +25,7 @@ describe('URL', () => {
       url: 'https://example2.com',
       type: 'json',
       source: 'url',
-    } as InfinityQuery;
+    } as InfinityQueryWithURLSource<InfinityQueryType>;
 
     rerender(<URL {...props} query={mockQuery2} />);
     expect(screen.getByDisplayValue('https://example2.com')).toBeInTheDocument();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsep-plugin/assignment@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.2.1.tgz#07277bdd7862451a865d391e2142efba33f46c9b"
+  integrity sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==
+
+"@jsep-plugin/regex@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.3.tgz#3aeaa2e5fa45d89de116aeafbfa41c95935b7f6d"
+  integrity sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==
+
 "@leeoniya/ufuzzy@1.0.13":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@leeoniya/ufuzzy/-/ufuzzy-1.0.13.tgz#d4812e339ee82589513f9d937f3da29044325b6d"
@@ -6782,6 +6792,11 @@ jsdom@^20.0.0:
     ws "^8.11.0"
     xml-name-validator "^4.0.0"
 
+jsep@^1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.3.9.tgz#8ce42df80ee9c1b39e52d0dd062a465342f35440"
+  integrity sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -6868,10 +6883,14 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
-  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
+jsonpath-plus@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-10.0.1.tgz#a61f4dc6c7489955af0872b0956cc42fbbacb5ab"
+  integrity sha512-30DeH2QD4nL1IpDLPIFz09G5XyLvh+oNMUI2Zxf4tbrlsVHs0e3VPnwpOnSTFb4yM0dfQK2WGKLsSaAS8V62rw==
+  dependencies:
+    "@jsep-plugin/assignment" "^1.2.1"
+    "@jsep-plugin/regex" "^1.0.3"
+    jsep "^1.3.9"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"


### PR DESCRIPTION
There was a breaking change in JSONPath

> 9.0.0
> BREAKING CHANGES:
>
> Removes preventEval property. Prefer eval: false instead.