### PR TITLE
use actual json instead of rendered web page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const DefaultInfinityQuery: InfinityQuery = {
   type: 'json',
   source: 'url',
   format: 'table',
-  url: 'https://github.com/grafana/grafana-infinity-datasource/blob/main/testdata/users.json',
+  url: 'https://raw.githubusercontent.com/grafana/grafana-infinity-datasource/refs/heads/main/testdata/users.json',
   url_options: { method: 'GET', data: '' },
   root_selector: '',
   columns: [],


### PR DESCRIPTION
For the defaults of the data source, it seems that the website used is actually the rendered web page of github instead of the json array. I wonder whether it would be more interesting to have the actual json array instead. I think it would be easier from the user's POV to test the plugin quickly (they still need to allow the github host).