### PR TITLE
fix incorrect gitlab url normalization

### DIFF
--- a/.changeset/orange-panthers-bow.md
+++ b/.changeset/orange-panthers-bow.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+🐛 **Bug fix**: Fixed a bug where gitlab urls were normalized incorrectly. Fixed [#962](Querying URL results in an error)

--- a/pkg/infinity/request.go
+++ b/pkg/infinity/request.go
@@ -83,7 +83,7 @@ func NormalizeURL(u string) string {
 		u = strings.Replace(u, "https://github.com", "https://raw.githubusercontent.com", 1)
 		u = strings.Replace(u, "/blob/", "/", 1)
 	}
-	if strings.HasPrefix(u, "https://gitlab.com") && len(urlArray) > 5 && urlArray[6] == "blob" && urlArray[5] != "blob" && urlArray[4] != "blob" && urlArray[3] != "blob" {
+	if strings.HasPrefix(u, "https://gitlab.com") && !strings.HasPrefix(u, "https://gitlab.com/api") && len(urlArray) > 5 && urlArray[6] == "blob" {
 		u = strings.Replace(u, "/blob/", "/raw/", 1)
 	}
 	if strings.HasPrefix(u, "https://bitbucket.org") && len(urlArray) > 4 && urlArray[5] == "src" {

--- a/pkg/infinity/request_test.go
+++ b/pkg/infinity/request_test.go
@@ -257,6 +257,7 @@ func TestNormalizeURL(t *testing.T) {
 		{u: "https://raw.githubusercontent.com/grafana/grafana-infinity-datasource/main/testdata/users.csv", want: "https://raw.githubusercontent.com/grafana/grafana-infinity-datasource/main/testdata/users.csv"},
 		{u: "https://foo.com/channels/38629/feed.json", want: "https://foo.com/channels/38629/feed.json"},
 		{u: "https://gitlab.com/restcountries/restcountries/-/blob/master/src/main/resources/countriesV3.json", want: "https://gitlab.com/restcountries/restcountries/-/raw/master/src/main/resources/countriesV3.json"},
+		{u: "https://gitlab.com/api/v4/projects", want: "https://gitlab.com/api/v4/projects"},
 		{u: "https://bitbucket.org/yesoreyeram/test_repo/src/master/data/countries.json", want: "https://bitbucket.org/yesoreyeram/test_repo/raw/master/data/countries.json"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
fix incorrect gitlab url normalization.

Fixes #962

## After fix

<img width="1578" alt="image" src="https://github.com/user-attachments/assets/b8f31963-1265-4ae3-87f5-9636db0eaa29">

<img width="1617" alt="image" src="https://github.com/user-attachments/assets/5ae4320f-e475-4b5b-9b68-aff02f41d357">
