### PR TITLE
Bump infinity-libs/lib/go/macros to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/grafana/infinity-libs/lib/go/framesql v1.0.2
 	github.com/grafana/infinity-libs/lib/go/gframer v1.0.0
 	github.com/grafana/infinity-libs/lib/go/jsonframer v1.1.4
-	github.com/grafana/infinity-libs/lib/go/macros v1.0.0
+	github.com/grafana/infinity-libs/lib/go/macros v1.0.1
 	github.com/grafana/infinity-libs/lib/go/transformations v1.0.3
 	github.com/grafana/infinity-libs/lib/go/xmlframer v1.0.0
 	github.com/icholy/digest v0.1.22

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/grafana/infinity-libs/lib/go/gframer v1.0.0 h1:TYKumCoWlf9KlXa6M9pi3s
 github.com/grafana/infinity-libs/lib/go/gframer v1.0.0/go.mod h1:tCjLSNFQnuYiNeBIAyb51jNV8ad0eI/M69P1rxm77Fc=
 github.com/grafana/infinity-libs/lib/go/jsonframer v1.1.4 h1:boSnUP+ZuFJByvfFozX7www10ApnAKPmsUfXcxl0YLI=
 github.com/grafana/infinity-libs/lib/go/jsonframer v1.1.4/go.mod h1:HLkUysTFcEDE6E/j2OHcd2TcpROSlqX1N3l4DkVTzdE=
-github.com/grafana/infinity-libs/lib/go/macros v1.0.0 h1:5IaWKGvY0zhli0MKfjKvS1Y+bzY758Yw8HELU4cqs6E=
-github.com/grafana/infinity-libs/lib/go/macros v1.0.0/go.mod h1:6EE8D9bV9J9nC9gQSD1HirqCKHhWKaEaZYJsajM6PGk=
+github.com/grafana/infinity-libs/lib/go/macros v1.0.1 h1:O5W6gOyJmqFZYZok/XYxIXfvunxh5cotoYIcxhqQwDk=
+github.com/grafana/infinity-libs/lib/go/macros v1.0.1/go.mod h1:YSL8uSrWqbVlKJaljBWwkHRr5/5XxF2Z9TRYfP8cl14=
 github.com/grafana/infinity-libs/lib/go/transformations v1.0.3 h1:1ruYu3D9IsfNF7o8jU4zIowbq99YnX77Lt/hmvIj3pg=
 github.com/grafana/infinity-libs/lib/go/transformations v1.0.3/go.mod h1:/WACyqQiCKo7lTezxRyMYaGYM/lVF8/u9b56z1amb40=
 github.com/grafana/infinity-libs/lib/go/utils v1.0.0 h1:jXlKDSay/S2tdaWghc0E7DzKugMQhEUcKtlVPmb69oc=


### PR DESCRIPTION
Bump infinity-libs/lib/go/macros to v1.0.1 to include fix for interpolating of time macros using UTC: https://github.com/grafana/infinity-libs/releases/tag/lib%2Fgo%2Fmacros%2Fv1.0.1 

Fixes: https://github.com/grafana/grafana-infinity-datasource/issues/966