### PR TITLE
Fix error source for invalid queries

### DIFF
--- a/.changeset/friendly-panthers-yell.md
+++ b/.changeset/friendly-panthers-yell.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix error source for invalid queries

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -310,8 +310,7 @@ func LoadQuery(ctx context.Context, backendQuery backend.DataQuery, pluginContex
 	var query Query
 	err := json.Unmarshal(backendQuery.JSON, &query)
 	if err != nil {
-		// Plugin error as the user should not have been able to send a bad query
-		return query, errorsource.PluginError(fmt.Errorf("error while parsing the query json. %w", err), false)
+		return query, errorsource.DownstreamError(fmt.Errorf("error while parsing the query json. %w", err), false)
 	}
 	query = ApplyDefaultsToQuery(ctx, query)
 	if query.PageMode == PaginationModeList && strings.TrimSpace(query.PageParamListFieldName) == "" {


### PR DESCRIPTION
Fixes https://github.com/grafana/data-sources/issues/179

The errors from `json.Unmarshal` of query should be downstream, as plugin expects correct query to work. Users can create invalid query through provisioning, or updating dashboard json. Therefore this needs to be downstream. 