### PR TITLE
feat: Injection trace into req.head

### DIFF
--- a/pkg/infinity/request.go
+++ b/pkg/infinity/request.go
@@ -34,6 +34,7 @@ func GetRequest(ctx context.Context, settings models.InfinitySettings, body io.R
 	req = ApplyBearerToken(settings, req, includeSect)
 	req = ApplyApiKeyAuth(settings, req, includeSect)
 	req = ApplyForwardedOAuthIdentity(requestHeaders, settings, req, includeSect)
+	req = ApplyTraceHead(ctx, req)
 	return req, err
 }
 


### PR DESCRIPTION
Using `TextMapPropagator` of `grafana-plugin-sdk-go` to inject tracking into http headers
see: https://opentelemetry.io/docs/specs/otel/context/api-propagators
