### PR TITLE
remove legacy class name from inline data input text area

### DIFF
--- a/src/editors/query/query.data.tsx
+++ b/src/editors/query/query.data.tsx
@@ -29,7 +29,6 @@ export const InlineDataEntry = ({ query, onChange, onRunQuery }: { query: Infini
       <EditorField label="Data" tooltip={'Inline Data'}>
         <TextArea
           rows={6}
-          className="gf-form-input"
           style={{ width: '600px' }}
           value={query.data}
           placeholder=""


### PR DESCRIPTION
This PR fixes the height of the text area. ( bug caused by legacy class name `gf-form-input` )

# Before

<img width="1371" alt="image" src="https://github.com/user-attachments/assets/0644a9c1-dacc-4635-b321-0f10235d0dd6" />

# After

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/a99ea506-c9c5-42b5-a119-e0724ca2e540" />

