### PR TITLE
Fix PR workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   ci:


### PR DESCRIPTION
Workflows are not getting triggered when targeting to non-main branch. Example : https://github.com/grafana/grafana-infinity-datasource/pull/1110

This PR removes the branch filter so that it should work.

Reported to @xnyo as well to update the docs.