### PR TITLE
pin go version to latest in pipelines

### DIFF
--- a/.changeset/few-seahorses-swim.md
+++ b/.changeset/few-seahorses-swim.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Build and publish pipelines uses latest go lang version `1.23.5` which includes security fixes to the `crypto/x509` and `net/http` packages ( CVE-2024-45341 and CVE-2024-45336 ). More details can be found [here](https://groups.google.com/g/golang-announce/c/sSaUhLA-2SI)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
-      go-version: '1.23'
+      go-version: '1.23.5'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
-      go-version: latest
+      go-version: '1.23'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
+      go-version: latest
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,6 @@ jobs:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
-      go-version: '1.23'
+      go-version: '1.23.5'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,6 @@ jobs:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
-      go-version: latest
+      go-version: '1.23'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,5 +11,6 @@ jobs:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
+      go-version: latest
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true


### PR DESCRIPTION
With the latest version of go released with security fixes, it is required to use latest version of go in pipelines to overcome those CVEs. ~~So this PR suggest to use latest go version always in pipelines so that we don't need to update the version every time.~~ 