### PR TITLE
Fix defaulting to frontend parser if not selected

### DIFF
--- a/.changeset/brave-dodos-sniff.md
+++ b/.changeset/brave-dodos-sniff.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix default parser for queries created before 3.0.0

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -2,11 +2,30 @@ import { InfinityQuery } from 'types/query.types';
 import { migrateQuery } from './migrate';
 
 describe('Query Migration', () => {
-  it('should set parser to simple when parser is undefined', () => {
+  it('should set parser to backend for new URL source query with empty URL', () => {
     const query = {
       refId: 'A',
       type: 'json',
       source: 'url',
+      url: '',
+      url_options: { method: 'GET', data: '' },
+    } as InfinityQuery;
+    const result = migrateQuery(query);
+    expect(result).toEqual({
+      ...query,
+      parser: 'backend',
+    });
+  });
+
+  // This is to ensure that old queries created before 3.0 continue to work as simple parser was the default parser
+  // and if users have not touched the parser field it was set to simple
+  it('should set parser to simple for existing queries without parser', () => {
+    const query = {
+      refId: 'A',
+      type: 'json',
+      source: 'url',
+      url: 'http://example.com',
+      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
     const result = migrateQuery(query);
     expect(result).toEqual({
@@ -20,23 +39,33 @@ describe('Query Migration', () => {
       refId: 'A',
       source: 'url',
       parser: 'backend',
+      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
     const result = migrateQuery(query);
     expect(result).toEqual(query);
   });
 
-  it('should preserve other fields while setting default parser', () => {
+  it('should not modify parser when root_selector is set', () => {
     const query = {
       refId: 'A',
       type: 'json',
       source: 'url',
-      url: 'http://example.com',
       root_selector: 'data',
+      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
     const result = migrateQuery(query);
-    expect(result).toEqual({
-      ...query,
-      parser: 'simple',
-    });
+    expect(result).toEqual(query);
+  });
+
+  it('should not modify parser when columns are defined', () => {
+    const query = {
+      refId: 'A',
+      type: 'json',
+      source: 'url',
+      columns: [{ selector: 'field', text: 'Field', type: 'string' }],
+      url_options: { method: 'GET', data: '' },
+    } as InfinityQuery;
+    const result = migrateQuery(query);
+    expect(result).toEqual(query);
   });
 });

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -1,0 +1,42 @@
+import { InfinityQuery } from 'types/query.types';
+import { migrateQuery } from './migrate';
+
+describe('Query Migration', () => {
+  it('should set parser to simple when parser is undefined', () => {
+    const query = {
+      refId: 'A',
+      type: 'json',
+      source: 'url',
+    } as InfinityQuery;
+    const result = migrateQuery(query);
+    expect(result).toEqual({
+      ...query,
+      parser: 'simple',
+    });
+  });
+
+  it('should not modify parser when it is already set', () => {
+    const query = {
+      refId: 'A',
+      source: 'url',
+      parser: 'backend',
+    } as InfinityQuery;
+    const result = migrateQuery(query);
+    expect(result).toEqual(query);
+  });
+
+  it('should preserve other fields while setting default parser', () => {
+    const query = {
+      refId: 'A',
+      type: 'json',
+      source: 'url',
+      url: 'http://example.com',
+      root_selector: 'data',
+    } as InfinityQuery;
+    const result = migrateQuery(query);
+    expect(result).toEqual({
+      ...query,
+      parser: 'simple',
+    });
+  });
+});

--- a/src/migrate.test.ts
+++ b/src/migrate.test.ts
@@ -1,16 +1,15 @@
 import { InfinityQuery } from 'types/query.types';
-import { migrateQuery } from './migrate';
+import { setDefaultParserToBackend } from './migrate';
 
-describe('Query Migration', () => {
+describe('setDefaultParserToBackend', () => {
   it('should set parser to backend for new URL source query with empty URL', () => {
     const query = {
       refId: 'A',
       type: 'json',
       source: 'url',
       url: '',
-      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
-    const result = migrateQuery(query);
+    const result = setDefaultParserToBackend(query);
     expect(result).toEqual({
       ...query,
       parser: 'backend',
@@ -25,9 +24,8 @@ describe('Query Migration', () => {
       type: 'json',
       source: 'url',
       url: 'http://example.com',
-      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
-    const result = migrateQuery(query);
+    const result = setDefaultParserToBackend(query);
     expect(result).toEqual({
       ...query,
       parser: 'simple',
@@ -39,9 +37,8 @@ describe('Query Migration', () => {
       refId: 'A',
       source: 'url',
       parser: 'backend',
-      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
-    const result = migrateQuery(query);
+    const result = setDefaultParserToBackend(query);
     expect(result).toEqual(query);
   });
 
@@ -51,9 +48,8 @@ describe('Query Migration', () => {
       type: 'json',
       source: 'url',
       root_selector: 'data',
-      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
-    const result = migrateQuery(query);
+    const result = setDefaultParserToBackend(query);
     expect(result).toEqual(query);
   });
 
@@ -63,9 +59,8 @@ describe('Query Migration', () => {
       type: 'json',
       source: 'url',
       columns: [{ selector: 'field', text: 'Field', type: 'string' }],
-      url_options: { method: 'GET', data: '' },
     } as InfinityQuery;
-    const result = migrateQuery(query);
+    const result = setDefaultParserToBackend(query);
     expect(result).toEqual(query);
   });
 });

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -47,6 +47,13 @@ export const setDefaultParserToBackend = (query: InfinityQuery): InfinityQuery =
   if (!isDataQuery(newQuery)) {
     return newQuery;
   }
+
+  // If query has no parser set it means that it was created before 3.0 and user has not touched the parser field.
+  // So we set the parser to simple which is the default parser.
+  if (newQuery?.parser === undefined) {
+    return { ...newQuery, parser: 'simple' };
+  }
+
   // if the parser is already set, we should respect that
   // if the root_selector is already set, overriding the parser type will break the queries with frontend parsing. So we should leave as it is
   // if the query have columns defined, overriding the parser type will break the queries with frontend parsing. So we should leave as it is

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,4 +1,3 @@
-import { DefaultInfinityQuery } from './constants';
 import { isDataQuery, isInfinityQueryWithUrlSource } from './app/utils';
 import type { InfinityQuery } from './types';
 


### PR DESCRIPTION
This PR fixes the logic to determine which parser we should use. In 3.0.0 we have changed the default parser to be `backend` instead of `simple (frontend)` ([PR here](https://github.com/grafana/grafana-infinity-datasource/pull/1140/files)). We added a logic to ensure that we don't break queries an keep originally selected parser

```
export const setDefaultParserToBackend = (query: InfinityQuery): InfinityQuery => {
  let newQuery: InfinityQuery = { ...query };
  if (!isDataQuery(newQuery)) {
    return newQuery;
  }
  // if the parser is already set, we should respect that
  // if the root_selector is already set, overriding the parser type will break the queries with frontend parsing. So we should leave as it is
  // if the query have columns defined, overriding the parser type will break the queries with frontend parsing. So we should leave as it is
  if (newQuery?.parser || newQuery?.root_selector || newQuery?.columns?.length > 0) {
    return newQuery;
  }
  return { ...newQuery, parser: 'backend' };
};
```

However, if users haven't touched the parser field, the parser is not set, but we want to default to `simple` as that's what was working before.

This PR adds a logic that adds the parser to `parser: 'backend'` if 
- parser is undefined
- query is new and has default fields

It also adds a logic  that adds the parser to `parser: 'simple'` if  
- parser is undefined
- query is not new and does not have default fields

I have added test to it.

Fixes https://github.com/grafana/support-escalations/issues/15279