### PR TITLE
Pagination: Fix min value in input field to be 0

### DIFF
--- a/.changeset/lovely-cats-run.md
+++ b/.changeset/lovely-cats-run.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix min value for input field in pagination

--- a/src/editors/query/query.pagination.tsx
+++ b/src/editors/query/query.pagination.tsx
@@ -37,7 +37,7 @@ export const PaginationEditor = (props: PaginationEditorProps) => {
             <Select<PaginationType> width={30} value={query.pagination_mode || 'none'} options={paginationTypes} onChange={(e) => onChange({ ...query, pagination_mode: e.value || 'none' })} />
           </EditorField>
           {query.pagination_mode && query.pagination_mode !== 'none' && (
-            <EditorField label="Max pages" tooltip={'Enter a value between 0 and a maximum of 5 pages, or the maximum page limit set in the Grafana configuration for the Infinity plugin.'}>
+            <EditorField label="Max pages" tooltip={'Enter a value up to 5 pages, or the maximum page limit set in the Grafana configuration for the Infinity plugin.'}>
               <Input
                 type={'number'}
                 min={0}

--- a/src/editors/query/query.pagination.tsx
+++ b/src/editors/query/query.pagination.tsx
@@ -37,10 +37,10 @@ export const PaginationEditor = (props: PaginationEditorProps) => {
             <Select<PaginationType> width={30} value={query.pagination_mode || 'none'} options={paginationTypes} onChange={(e) => onChange({ ...query, pagination_mode: e.value || 'none' })} />
           </EditorField>
           {query.pagination_mode && query.pagination_mode !== 'none' && (
-            <EditorField label="Max pages" tooltip={'Enter a value between 1 and a maximum of 5 pages, or the maximum page limit set in the Grafana configuration for the Infinity plugin.'}>
+            <EditorField label="Max pages" tooltip={'Enter a value between 0 and a maximum of 5 pages, or the maximum page limit set in the Grafana configuration for the Infinity plugin.'}>
               <Input
                 type={'number'}
-                min={1}
+                min={0}
                 width={30}
                 value={query.pagination_max_pages}
                 onChange={(e) => onChange({ ...query, pagination_max_pages: e.currentTarget.valueAsNumber || 1 })}
@@ -73,7 +73,7 @@ export const PaginationEditor = (props: PaginationEditorProps) => {
                     width={20}
                     type="number"
                     value={query.pagination_param_size_value}
-                    min={1}
+                    min={0}
                     max={2000}
                     onChange={(e) => onChange({ ...query, pagination_param_size_value: e.currentTarget.valueAsNumber || 0 })}
                   ></Input>
@@ -103,7 +103,7 @@ export const PaginationEditor = (props: PaginationEditorProps) => {
                       width={20}
                       type="number"
                       value={query.pagination_param_offset_value}
-                      min={1}
+                      min={0}
                       max={2000}
                       onChange={(e) => onChange({ ...query, pagination_param_offset_value: e.currentTarget.valueAsNumber || 0 })}
                     ></Input>
@@ -134,7 +134,7 @@ export const PaginationEditor = (props: PaginationEditorProps) => {
                       width={20}
                       type="number"
                       value={query.pagination_param_page_value}
-                      min={1}
+                      min={0}
                       onChange={(e) => onChange({ ...query, pagination_param_page_value: e.currentTarget.valueAsNumber || 1 })}
                     ></Input>
                   </Stack>


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-infinity-datasource/issues/1165

Changes min value for pagination input fields to `0`. This fixes a bug where users weren't able to start with 0 in pagination. It does not change the default behavior, just lets users type `0` to field. I have checked and all of these have handling for `0` value: https://github.com/grafana/grafana-infinity-datasource/blob/main/pkg/models/query.go#L265