### PR TITLE
Fix CD action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
       go-version: '1.24.1'
+      golangci-lint-version: '1.64.6'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}


### PR DESCRIPTION
Fix CD pipeline that is failing on `golangci-lint` error  https://github.com/grafana/grafana-infinity-datasource/actions/runs/13972121536/job/39116826508. We should use the same `golangci-lint-version` in CD action as we use in [CI action](https://github.com/grafana/grafana-infinity-datasource/blob/main/.github/workflows/push.yaml#L15)
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/42ead51c-52d0-4a88-9c50-a0ee26751b21" />
