### PR TITLE
Fix error when setting up global query

### DIFF
--- a/.changeset/fair-schools-repeat.md
+++ b/.changeset/fair-schools-repeat.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix error when setting up global query

--- a/package.json
+++ b/package.json
@@ -134,5 +134,6 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-livereload-plugin": "^3.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,5 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-livereload-plugin": "^3.0.2"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/editors/query/query.options.tsx
+++ b/src/editors/query/query.options.tsx
@@ -24,7 +24,7 @@ export const BasicOptions = (props: {
   onShowUrlOptions: () => void;
   onShowHelp: () => void;
 }) => {
-  const { query, mode, onChange, onRunQuery, onShowUrlOptions, onShowHelp, datasource } = props;
+  const { query, mode, onChange, onRunQuery, onShowUrlOptions, onShowHelp, datasource, instanceSettings } = props;
   return (
     <>
       <EditorRow label="Query options">
@@ -61,7 +61,7 @@ export const BasicOptions = (props: {
       </EditorRow>
       {isInfinityQueryWithUrlSource(query) && (
         <EditorRow label={'URL'}>
-          <Method query={query} onChange={onChange} onRunQuery={onRunQuery} allowDangerousHTTPMethods={datasource.instanceSettings.jsonData.allowDangerousHTTPMethods} />
+          <Method query={query} onChange={onChange} onRunQuery={onRunQuery} allowDangerousHTTPMethods={!!instanceSettings.jsonData.allowDangerousHTTPMethods} />
           <URL query={query as InfinityQueryWithURLSource<InfinityQueryType>} onChange={onChange} onRunQuery={onRunQuery} onShowUrlOptions={onShowUrlOptions} />
           <Button
             variant="secondary"


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-infinity-datasource/issues/1178


This PR fixes error when setting up Global query in data source config. In `query.options.tx` we were using `datasource.instanceSettings.jsonData.allowDangerousHTTPMethods`, but `instanceSettings` can be in this case undefined because we are in config page and have not set them up.

We were supposed to be using `instanceSettings.jsonData.allowDangerousHTTPMethods` as: 
- in config page we are passing currently selected option as `instanceSettings`, so this is going to correctly work
- in query editor, nothing changes because we are passing `datasource.instanceSettings` as `instanceSettings` so it is the same.

### Fixed on this branch:

https://github.com/user-attachments/assets/99cf18c6-2a8d-43df-9012-2952b1ab2a6e


### Broken on main branch:

https://github.com/user-attachments/assets/8a213afe-0842-4cef-8e65-5ca452e6b971
