### PR TITLE
Add infinity learning journey to the plugin docs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -63,10 +63,18 @@ You can download and install this grafana plugin using various options
 
 For the plugin documentation, visit [plugin documentation website](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource).
 
+> [!TIP]
+> 
+> ## Give it a try using Grafana Play
+> 
+> With Grafana Play, you can explore and see how it works, learning from practical examples to accelerate your development. This feature can be seen on [Infinity plugin demo](https://play.grafana.org/d/infinity/).
+
 ## ⚡️ Useful Links
 
 - [Plugin documentation](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource)
 - [Demo video](https://youtu.be/Wmgs1E9Ry-s)
+- [Visualize CSV data Learning Journey](https://grafana.com/docs/learning-journeys/infinity-csv/)
+- [Visualize JSON data Learning Journey](https://grafana.com/docs/learning-journeys/infinity-json/)
 
 ## 👍 Contributing
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -53,9 +53,9 @@ weight: 10
 
 A universal data source plugin for pulling data from various systems into Grafana using existing REST APIs. Grafana's go-to plugin for cases when a native plugin doesn’t exist yet.
 
-<p align="center">
-    <img src="https://user-images.githubusercontent.com/153843/189875668-3ac061a9-c548-4bfe-abcc-6d0d7e6bdb55.png" alt="Infinity datasource plugin for Grafana">
-</p>
+Watch this video to get started with the Grafana Infinity data source plugin:
+
+{{< youtube id="BxWw4BWY5ns" >}}
 
 {{< docs/play title="Infinity plugin demo" url="https://play.grafana.org/d/infinity" >}}
 

--- a/docs/sources/csv.md
+++ b/docs/sources/csv.md
@@ -37,11 +37,17 @@ weight: 22
 
 Looking for a quick start example? Please check [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/). This page covers details the various powerful configuration options for dealing with CSV data in Infinity.
 
+Alternatively, for a more concise learning journey, check out our Grafana Infinity data source learning journey:
+
+{{< docs/learning-journeys title="Visualize CSV data using the Infinity data source" url="https://grafana.com/docs/learning-journeys/infinity-csv/" >}}
+
 <div style="margin-bottom:30px"></div>
 
 ![csv example](https://user-images.githubusercontent.com/153843/92571108-9e0ff800-f27a-11ea-9fe9-9f9dcbd7125a.png#center)
 
 {{< docs/play title="Infinity plugin CSV demo" url="https://play.grafana.org/d/infinity-csv" >}}
+
+<div style="margin-bottom:30px"></div>
 
 Select **Type** of the query to `CSV`. You can either specify the URL of the CSV file or can provide inline CSV.
 

--- a/docs/sources/json.md
+++ b/docs/sources/json.md
@@ -35,11 +35,17 @@ weight: 21
 
 ## 📊 Overview
 
+For a more concise learning journey, check out our Grafana Infinity data source learning journey:
+
+{{< docs/learning-journeys title="Visualize JSON data using the Infinity data source" url="https://grafana.com/docs/learning-journeys/infinity-json/" >}}
+
 <div style="margin-bottom:30px"></div>
 
 ![Sample JSON Query in Infinity datasource](https://user-images.githubusercontent.com/153843/189874914-6b49d3ec-2030-46ea-b14e-fdd48628345e.png#center)
 
 {{< docs/play title="Infinity plugin JSON demo" url="https://play.grafana.org/d/infinity-json" >}}
+
+<div style="margin-bottom:30px"></div>
 
 Select **Type** of the query to `JSON`. You can either specify the URL of the JSON API, JSON file or can provide inline CSV.
 


### PR DESCRIPTION
This PR adds the Infinity learning journey to the plugin docs to increase traffic and visibility for learning journeys. I've also added the get-started video to the index file.