### PR TITLE
feat: add AcceptErrorStatusCodes setting to allow processing HTTP err…

### DIFF
--- a/pkg/infinity/client.go
+++ b/pkg/infinity/client.go
@@ -140,7 +140,7 @@ func (client *Client) req(ctx context.Context, pCtx *backend.PluginContext, url 
 		logger.Debug("invalid response from server and also no error", "url", url, "method", req.Method)
 		return nil, http.StatusInternalServerError, duration, backend.DownstreamError(fmt.Errorf("invalid response received for the URL %s", url))
 	}
-	if res.StatusCode >= http.StatusBadRequest {
+	if res.StatusCode >= http.StatusBadRequest && !settings.AcceptErrorStatusCodes {
 		err = fmt.Errorf("%w. %s", models.ErrUnsuccessfulHTTPResponseStatus, res.Status)
 		// Infinity can query anything and users are responsible for ensuring that endpoint/auth is correct
 		// therefore any incoming error is considered downstream

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -119,6 +119,7 @@ type InfinitySettings struct {
 	UnsecuredQueryHandling    UnsecuredQueryHandlingMode
 	PathEncodedURLsEnabled    bool
 	AllowDangerousHTTPMethods bool
+	AcceptErrorStatusCodes    bool
 	// ProxyOpts is used for Secure Socks Proxy configuration
 	ProxyOpts httpclient.Options
 }
@@ -204,6 +205,7 @@ type InfinitySettingsJson struct {
 	AzureBlobAccountName      string         `json:"azureBlobAccountName,omitempty"`
 	PathEncodedURLsEnabled    bool           `json:"pathEncodedUrlsEnabled,omitempty"`
 	AllowDangerousHTTPMethods bool           `json:"allowDangerousHTTPMethods,omitempty"`
+	AcceptErrorStatusCodes    bool           `json:"acceptErrorStatusCodes,omitempty"`
 	// Security
 	AllowedHosts           []string                   `json:"allowedHosts,omitempty"`
 	UnsecuredQueryHandling UnsecuredQueryHandlingMode `json:"unsecuredQueryHandling,omitempty"`
@@ -248,6 +250,7 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 		settings.ProxyUrl = infJson.ProxyUrl
 		settings.PathEncodedURLsEnabled = infJson.PathEncodedURLsEnabled
 		settings.AllowDangerousHTTPMethods = infJson.AllowDangerousHTTPMethods
+		settings.AcceptErrorStatusCodes = infJson.AcceptErrorStatusCodes
 		if settings.ProxyType == "" {
 			settings.ProxyType = ProxyTypeEnv
 		}

--- a/src/editors/config/URL.tsx
+++ b/src/editors/config/URL.tsx
@@ -53,6 +53,23 @@ export const URLSettingsEditor = (props: DataSourcePluginOptionsEditorProps<Infi
         <InlineSwitch value={jsonData.pathEncodedUrlsEnabled || false} onChange={(e) => onOptionsChange({ ...options, jsonData: { ...jsonData, pathEncodedUrlsEnabled: e.currentTarget.checked } })} />
         <Badge text="Experimental" color="orange" icon={'exclamation-triangle'} />
       </Stack>
+      <Stack>
+        <InlineLabel
+          width={36}
+          tooltip={`When enabled, the datasource will process response body even for HTTP error status codes (4xx, 5xx). This is useful for APIs that return useful data in error responses, such as detailed error messages or partial data during service degradation.`}
+        >
+          Accept error status codes
+        </InlineLabel>
+        <InlineSwitch
+          value={jsonData.acceptErrorStatusCodes || false}
+          onChange={(e) =>
+            onOptionsChange({
+              ...options,
+              jsonData: { ...jsonData, acceptErrorStatusCodes: e.currentTarget.checked },
+            })
+          }
+        />
+      </Stack>
     </Stack>
   );
 };

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -55,6 +55,7 @@ export interface InfinityOptions extends DataSourceJsonData {
   enableSecureSocksProxy?: boolean;
   pathEncodedUrlsEnabled?: boolean;
   allowDangerousHTTPMethods?: boolean;
+  acceptErrorStatusCodes?: boolean;
 }
 
 export interface InfinitySecureOptions {


### PR DESCRIPTION
## Summary

This PR adds a new `AcceptErrorStatusCodes` boolean setting to the Grafana Infinity Datasource that allows processing HTTP error response bodies (4xx/5xx status codes) instead of immediately treating them as errors.

## Changes Made

### Backend (Go)
- Added `AcceptErrorStatusCodes` field to `InfinitySettings` and `InfinitySettingsJson` structs in `pkg/models/settings.go`
- Modified HTTP client logic in `pkg/infinity/client.go` to respect the new setting
- Updated status code check: `if res.StatusCode >= http.StatusBadRequest && !settings.AcceptErrorStatusCodes`

### Frontend (TypeScript/React)
- Added `acceptErrorStatusCodes?: boolean` to `InfinityOptions` interface in `src/types/config.types.ts`
- Added UI toggle in URL settings section in `src/editors/config/URL.tsx` with descriptive tooltip

## Use Case

This feature is useful for APIs that return meaningful data in error responses, such as:
- 503 Service Unavailable responses that include detailed error information
- APIs that provide partial data during service degradation
- Error responses with structured JSON containing diagnostic information

## Backward Compatibility

- **Default behavior unchanged**: The setting defaults to `false`, maintaining existing behavior
- **No breaking changes**: Existing configurations will continue to work as before

## Testing

- ✅ Backend builds successfully with Go 1.24.1
- ✅ Frontend builds successfully with npm
- ✅ All existing tests pass
- ✅ Feature tested with HTTP 503 responses

## Screenshot

![image](https://github.com/user-attachments/assets/f6cf4fd0-49d3-4ed9-b405-7c44fe9060cc)
