### PR TITLE
Forward cookies if jsonData.keepCookies is specified in datasource config

### DIFF
--- a/.changeset/friendly-rules-marry.md
+++ b/.changeset/friendly-rules-marry.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Forward cookies if jsonData.keepCookies is specified in datasource config

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -180,7 +180,10 @@ func getQueryReqHeader(requestHeaders map[string]string, headerName string) stri
 // Grafana appears to provide only the specified cookies in the requestHeaders
 func ApplyForwardedCookies(_ context.Context, settings models.InfinitySettings, req *http.Request, requestHeaders map[string]string) *http.Request {
 	if len(settings.KeepCookies) >= 1 {
-		req.Header.Set("Cookie", requestHeaders["Cookie"])
+		cookie, ok := requestHeaders["Cookie"]
+		if ok {
+			req.Header.Set("Cookie", cookie)
+		}
 	}
 	return req
 }

--- a/pkg/infinity/headers.go
+++ b/pkg/infinity/headers.go
@@ -175,3 +175,12 @@ func getQueryReqHeader(requestHeaders map[string]string, headerName string) stri
 
 	return ""
 }
+
+// For extra precaution, only forwards cookies if jsonData.keepCookies is set for the datasource
+// Grafana appears to provide only the specified cookies in the requestHeaders
+func ApplyForwardedCookies(_ context.Context, settings models.InfinitySettings, req *http.Request, requestHeaders map[string]string) *http.Request {
+	if len(settings.KeepCookies) >= 1 {
+		req.Header.Set("Cookie", requestHeaders["Cookie"])
+	}
+	return req
+}

--- a/pkg/infinity/request.go
+++ b/pkg/infinity/request.go
@@ -46,6 +46,7 @@ func GetRequest(ctx context.Context, pCtx *backend.PluginContext, settings model
 	req = ApplyApiKeyAuth(ctx, settings, req, includeSect)
 	req = ApplyForwardedOAuthIdentity(ctx, requestHeaders, settings, req, includeSect)
 	req = ApplyTraceHead(ctx, req)
+	req = ApplyForwardedCookies(ctx, settings, req, requestHeaders)
 	return req, err
 }
 

--- a/pkg/infinity/request_test.go
+++ b/pkg/infinity/request_test.go
@@ -82,6 +82,20 @@ func TestGetRequest(t *testing.T) {
 			wantReq:     &http.Request{URL: &url.URL{}, Method: http.MethodPatch},
 			wantReqBody: true,
 		},
+		{
+			name:     "should forward cookies correctly when set in the keepCookies settings",
+			pCtx:     &backend.PluginContext{PluginID: "hello"},
+			settings: models.InfinitySettings{KeepCookies: []string{"cookie1"}},
+			requestHeaders: map[string]string{"Cookie": "cookie1=test"},
+			wantReq:  &http.Request{URL: &url.URL{}, Header: http.Header{"Cookie": []string{"cookie1=test"}}, Method: http.MethodGet},
+		},
+		{
+			name:     "should not forward cookies if keepCookies is not set in the settings",
+			pCtx:     &backend.PluginContext{PluginID: "hello"},
+			settings: models.InfinitySettings{},
+			requestHeaders: map[string]string{"Cookie": "cookie1=test"},
+			wantReq:  &http.Request{URL: &url.URL{}, Header: http.Header{}, Method: http.MethodGet},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/infinity/request_test.go
+++ b/pkg/infinity/request_test.go
@@ -96,6 +96,13 @@ func TestGetRequest(t *testing.T) {
 			requestHeaders: map[string]string{"Cookie": "cookie1=test"},
 			wantReq:  &http.Request{URL: &url.URL{}, Header: http.Header{}, Method: http.MethodGet},
 		},
+		{
+			name:     "handles no cookies present",
+			pCtx:     &backend.PluginContext{PluginID: "hello"},
+			settings: models.InfinitySettings{KeepCookies: []string{"cookie1"}},
+			requestHeaders: map[string]string{"AnotherHeader": "test"},
+			wantReq:  &http.Request{URL: &url.URL{}, Header: http.Header{}, Method: http.MethodGet},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -122,6 +122,8 @@ type InfinitySettings struct {
 	AllowDangerousHTTPMethods bool
 	// ProxyOpts is used for Secure Socks Proxy configuration
 	ProxyOpts httpclient.Options
+	// Specific cookies included by Grafana for forwarding
+	KeepCookies               []string
 }
 
 func (s *InfinitySettings) Validate() error {
@@ -209,6 +211,7 @@ type InfinitySettingsJson struct {
 	// Security
 	AllowedHosts           []string                   `json:"allowedHosts,omitempty"`
 	UnsecuredQueryHandling UnsecuredQueryHandlingMode `json:"unsecuredQueryHandling,omitempty"`
+	KeepCookies            []string                   `json:"keepCookies,omitempty"`
 }
 
 func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings) (settings InfinitySettings, err error) {
@@ -263,6 +266,9 @@ func LoadSettings(ctx context.Context, config backend.DataSourceInstanceSettings
 		}
 		if len(infJson.AllowedHosts) > 0 {
 			settings.AllowedHosts = infJson.AllowedHosts
+		}
+		if len(infJson.KeepCookies) > 0 {
+			settings.KeepCookies = infJson.KeepCookies
 		}
 	}
 	settings.ReferenceData = infJson.ReferenceData

--- a/pkg/models/settings_test.go
+++ b/pkg/models/settings_test.go
@@ -155,6 +155,7 @@ func TestAllSettingsAgainstFrontEnd(t *testing.T) {
 			"proxy_type" : "url",
 			"proxy_url" : "https://foo.com",
 			"allowedHosts": ["host1","host2"],
+			"keepCookies": ["cookie1","cookie2"],
 			"customHealthCheckEnabled" : true,
 			"customHealthCheckUrl" : "https://foo-check/",
 			"allowDangerousHTTPMethods": true,
@@ -252,6 +253,7 @@ func TestAllSettingsAgainstFrontEnd(t *testing.T) {
 		SecureQueryFields: map[string]string{
 			"foo": "bar",
 		},
+		KeepCookies:               []string{"cookie1", "cookie2"},
 	}, gotSettings)
 }
 


### PR DESCRIPTION
Grafana supports forwarding cookies to backend datasources if `keepCookies` is enabled for the datasource: https://github.com/grafana/grafana/pull/58132

This PR includes the cookies received from Grafana in the actual request. As an extra precaution, the request is only modified if `keepCookies` is enabled in the settings - otherwise there is no difference.

There should be no security concerns as Grafana passes _only_ the allowed cookies specified in `keepCookies` to `QueryDataRequest.Headers` (which becomes `requestHeaders` in the relevant code): https://github.com/grafana/grafana/pull/49541

Cookie forwarding is a necessity when Grafana is protected behind 3rd party authentication.