### PR TITLE
oauth2 custom token format

### DIFF
--- a/.changeset/nervous-jeans-appear.md
+++ b/.changeset/nervous-jeans-appear.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Plugin backend built with golang 1.24.4

--- a/.changeset/twenty-mugs-buy.md
+++ b/.changeset/twenty-mugs-buy.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+OAuth2: Allow custom token header and token prefix

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
-      go-version: '1.24.3'
+      go-version: '1.24.4'
       golangci-lint-version: '1.64.6'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
-      go-version: '1.24.3'
+      go-version: '1.24.4'
       golangci-lint-version: '1.64.6'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you want to contribute to the plugin, you can contribute in one of the follow
 You need following tools in your local machine for development
 
 - NodeJS v20.0+
-- Go 1.22
+- Go 1.24.4
 - Mage
 
 Once you clone the repo locally in the grafana's plugin folder. Do the following steps
@@ -21,7 +21,7 @@ Once you clone the repo locally in the grafana's plugin folder. Do the following
 - `yarn dev` - For continuously watching the front-end changes and build
 - `yarn build` - For building the frontend components
 - `mage -v` - This will help to build the backend part of the plugin. Do this once if you are contributing only the frontend. There is no significant code is in the backend. So no much changes expected
-- `docker-compose up` - To run the plugin with grafana locally. ( use infinity:infinity as the credentials ). You can also enable traces and logs with debug mode. Refer the **Setting up grafana in debug mode** section below
+- `docker compose up` - To run the plugin with grafana locally. ( use infinity:infinity as the credentials ). You can also enable traces and logs with debug mode. Refer the **Setting up grafana in debug mode** section below
 
 ## Submitting PR
 

--- a/docs/sources/setup/authentication.md
+++ b/docs/sources/setup/authentication.md
@@ -91,6 +91,9 @@ OAuth 2.0 client credentials require the following parameters:
 | **Token URL**       | TokenURL is the resource server's token endpoint URL. This is a constant specific to each server. |
 | **Scopes**          | Scope specifies optional requested permissions.                                                   |
 | **Endpoint params** | EndpointParams specifies additional parameters for requests to the token endpoint.                |
+| **Custom Token Header** | Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization |
+| **Custom Token Prefix** | Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer [https://datatracker.ietf.org/doc/html/rfc6749#section-7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) for more details. Defaults to Bearer |
+| **Skip Space in Token** | If selected, space between token prefix and token will be skipped |
 
 ## OAuth 2.0 JWT
 
@@ -104,6 +107,9 @@ OAuth 2.0 JWT require the following parameters
 | **Token URL**              | TokenURL is the endpoint required to complete the 2-legged JWT flow.                                              |
 | **Subject**                | Optional. Subject is the optional user to impersonate.                                                            |
 | **Scopes**                 | Scopes optionally specifies a list of requested permission scopes. Provide scopes as a comma separated values.    |
+| **Custom Token Header**    | Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization |
+| **Custom Token Prefix**    | Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer [https://datatracker.ietf.org/doc/html/rfc6749#section-7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) for more details. Defaults to Bearer |
+| **Skip Space in Token**    | If selected, space between token prefix and token will be skipped |
 
 ## Azure
 

--- a/docs/sources/setup/authentication.md
+++ b/docs/sources/setup/authentication.md
@@ -91,9 +91,8 @@ OAuth 2.0 client credentials require the following parameters:
 | **Token URL**       | TokenURL is the resource server's token endpoint URL. This is a constant specific to each server. |
 | **Scopes**          | Scope specifies optional requested permissions.                                                   |
 | **Endpoint params** | EndpointParams specifies additional parameters for requests to the token endpoint.                |
-| **Custom Token Header** | Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization |
-| **Custom Token Prefix** | Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer [https://datatracker.ietf.org/doc/html/rfc6749#section-7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) for more details. Defaults to Bearer |
-| **Skip Space in Token** | If selected, space between token prefix and token will be skipped |
+| **Custom Token Header**   | Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization |
+| **Custom Token Template** | Token Template allows you to customize the token value using the template. This will be Authorization header value. String `{{ access_token }}` will be replaced with actual access token |
 
 ## OAuth 2.0 JWT
 
@@ -108,8 +107,7 @@ OAuth 2.0 JWT require the following parameters
 | **Subject**                | Optional. Subject is the optional user to impersonate.                                                            |
 | **Scopes**                 | Scopes optionally specifies a list of requested permission scopes. Provide scopes as a comma separated values.    |
 | **Custom Token Header**    | Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization |
-| **Custom Token Prefix**    | Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer [https://datatracker.ietf.org/doc/html/rfc6749#section-7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1) for more details. Defaults to Bearer |
-| **Skip Space in Token**    | If selected, space between token prefix and token will be skipped |
+| **Custom Token Template**  | Token Template allows you to customize the token value using the template. This will be Authorization header value. String `{{ access_token }}` will be replaced with actual access token |
 
 ## Azure
 

--- a/docs/sources/setup/installation.md
+++ b/docs/sources/setup/installation.md
@@ -39,19 +39,19 @@ Download the required version of release archive from [GitHub](https://github.co
 If you are using grafana-cli, execute the following command to install the latest published version of the plugin
 
 ```shell
-grafana-cli plugins install yesoreyeram-infinity-datasource
+grafana cli plugins install yesoreyeram-infinity-datasource
 ```
 
 If you need custom version of the plugin from github, you can install using the following command.
 
 ```shell
-grafana-cli --pluginUrl <ZIP_FILE_URL> plugins install yesoreyeram-infinity-datasource
+grafana cli --pluginUrl <ZIP_FILE_URL> plugins install yesoreyeram-infinity-datasource
 ```
 
 Example:
 
 ```shell
-grafana-cli --pluginUrl https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.4.0/yesoreyeram-infinity-datasource-2.4.0.zip plugins install yesoreyeram-infinity-datasource
+grafana cli --pluginUrl https://github.com/grafana/grafana-infinity-datasource/releases/download/v3.3.0/yesoreyeram-infinity-datasource-3.3.0.zip plugins install yesoreyeram-infinity-datasource
 ```
 
 ## Install using helm chart
@@ -74,7 +74,7 @@ Example:
 
 ```yml
 plugins:
-  - https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.4.0/yesoreyeram-infinity-datasource-2.4.0.zip;yesoreyeram-infinity-datasource
+  - https://github.com/grafana/grafana-infinity-datasource/releases/download/v3.3.0/yesoreyeram-infinity-datasource-3.3.0.zip;yesoreyeram-infinity-datasource
 ```
 
 ## Install using Docker
@@ -82,11 +82,11 @@ plugins:
 With Docker, you can install the plugin using the following command. This will download the latest published version of the plugin from Grafana plugins directory.
 
 ```shell
-docker run -p 3000:3000 -e "GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource" grafana/grafana-enterprise:10.2.3
+docker run -p 3000:3000 -e "GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource" grafana/grafana-enterprise:latest
 ```
 
 If you need to install a custom version of the plugin with Docker, use the following command:
 
 ```shell
-docker run -p 3000:3000 -e "GF_INSTALL_PLUGINS=https://github.com/grafana/grafana-infinity-datasource/releases/download/v2.4.0/yesoreyeram-infinity-datasource-2.4.0.zip;yesoreyeram-infinity-datasource" grafana/grafana-enterprise:10.2.3
+docker run -p 3000:3000 -e "GF_INSTALL_PLUGINS=https://github.com/grafana/grafana-infinity-datasource/releases/download/v3.3.0/yesoreyeram-infinity-datasource-3.3.0.zip;yesoreyeram-infinity-datasource" grafana/grafana-enterprise:latest
 ```

--- a/go.mod
+++ b/go.mod
@@ -139,3 +139,5 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace golang.org/x/oauth2 v0.29.0 => github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082

--- a/go.mod
+++ b/go.mod
@@ -140,4 +140,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace golang.org/x/oauth2 v0.29.0 => github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082
+replace golang.org/x/oauth2 v0.29.0 => github.com/grafana/oauth2 v0.0.0-20250606041833-478a0f4fbdd5

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/grafana/infinity-libs/lib/go/utils v1.0.1 h1:eA/kfSTtnzutzajmijIG9LUu
 github.com/grafana/infinity-libs/lib/go/utils v1.0.1/go.mod h1:+hkrwV9ib8dsTCQDNh29PPE8Cnr9sy+w2XzuhrYqPTU=
 github.com/grafana/infinity-libs/lib/go/xmlframer v1.0.3 h1:uKb2sHekW+eCJ34/SlGsoI2JUu6/4/F/mI0uBYeCF48=
 github.com/grafana/infinity-libs/lib/go/xmlframer v1.0.3/go.mod h1:Y0O6Cbztd8e9oVx+M9kd1E5XorjNeDtOorrX2vxSkuk=
-github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082 h1:raSQrVZvnWSHEmoE664NA9xJ0n2zrGNAzjWR2GcuIs4=
-github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+github.com/grafana/oauth2 v0.0.0-20250606041833-478a0f4fbdd5 h1:dvy/xT8rWvJVT4pH8yMsOCI0wOJrXSN3G7ChxSzFLJo=
+github.com/grafana/oauth2 v0.0.0-20250606041833-478a0f4fbdd5/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/grafana/infinity-libs/lib/go/utils v1.0.1 h1:eA/kfSTtnzutzajmijIG9LUu
 github.com/grafana/infinity-libs/lib/go/utils v1.0.1/go.mod h1:+hkrwV9ib8dsTCQDNh29PPE8Cnr9sy+w2XzuhrYqPTU=
 github.com/grafana/infinity-libs/lib/go/xmlframer v1.0.3 h1:uKb2sHekW+eCJ34/SlGsoI2JUu6/4/F/mI0uBYeCF48=
 github.com/grafana/infinity-libs/lib/go/xmlframer v1.0.3/go.mod h1:Y0O6Cbztd8e9oVx+M9kd1E5XorjNeDtOorrX2vxSkuk=
+github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082 h1:raSQrVZvnWSHEmoE664NA9xJ0n2zrGNAzjWR2GcuIs4=
+github.com/grafana/oauth2 v0.0.0-20250605095642-73fc75bdb082/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
@@ -361,8 +363,6 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
-golang.org/x/oauth2 v0.29.0 h1:WdYw2tdTK1S8olAzWHdgeqfy+Mtm9XNhv/xJsY65d98=
-golang.org/x/oauth2 v0.29.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -113,12 +113,15 @@ func applyOAuthClientCredentials(ctx context.Context, httpClient *http.Client, s
 	defer span.End()
 	if isOAuthCredentialsConfigured(settings) {
 		oauthConfig := clientcredentials.Config{
-			ClientID:       settings.OAuth2Settings.ClientID,
-			ClientSecret:   settings.OAuth2Settings.ClientSecret,
-			TokenURL:       settings.OAuth2Settings.TokenURL,
-			Scopes:         []string{},
-			EndpointParams: url.Values{},
-			AuthStyle:      settings.OAuth2Settings.AuthStyle,
+			ClientID:         settings.OAuth2Settings.ClientID,
+			ClientSecret:     settings.OAuth2Settings.ClientSecret,
+			TokenURL:         settings.OAuth2Settings.TokenURL,
+			Scopes:           []string{},
+			EndpointParams:   url.Values{},
+			AuthStyle:        settings.OAuth2Settings.AuthStyle,
+			TokenType:        settings.OAuth2Settings.TokenType,
+			AuthHeader:       settings.OAuth2Settings.AuthHeader,
+			SkipSpaceInToken: settings.OAuth2Settings.SkipSpaceInToken,
 		}
 		for _, scope := range settings.OAuth2Settings.Scopes {
 			if scope != "" {
@@ -145,12 +148,15 @@ func applyOAuthJWT(ctx context.Context, httpClient *http.Client, settings models
 	defer span.End()
 	if isOAuthJWTConfigured(settings) {
 		jwtConfig := jwt.Config{
-			Email:        settings.OAuth2Settings.Email,
-			TokenURL:     settings.OAuth2Settings.TokenURL,
-			PrivateKey:   []byte(strings.ReplaceAll(settings.OAuth2Settings.PrivateKey, "\\n", "\n")),
-			PrivateKeyID: settings.OAuth2Settings.PrivateKeyID,
-			Subject:      settings.OAuth2Settings.Subject,
-			Scopes:       []string{},
+			Email:            settings.OAuth2Settings.Email,
+			TokenURL:         settings.OAuth2Settings.TokenURL,
+			PrivateKey:       []byte(strings.ReplaceAll(settings.OAuth2Settings.PrivateKey, "\\n", "\n")),
+			PrivateKeyID:     settings.OAuth2Settings.PrivateKeyID,
+			Subject:          settings.OAuth2Settings.Subject,
+			TokenType:        settings.OAuth2Settings.TokenType,
+			AuthHeader:       settings.OAuth2Settings.AuthHeader,
+			SkipSpaceInToken: settings.OAuth2Settings.SkipSpaceInToken,
+			Scopes:           []string{},
 		}
 		for _, scope := range settings.OAuth2Settings.Scopes {
 			if scope != "" {

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -113,15 +113,14 @@ func applyOAuthClientCredentials(ctx context.Context, httpClient *http.Client, s
 	defer span.End()
 	if isOAuthCredentialsConfigured(settings) {
 		oauthConfig := clientcredentials.Config{
-			ClientID:         settings.OAuth2Settings.ClientID,
-			ClientSecret:     settings.OAuth2Settings.ClientSecret,
-			TokenURL:         settings.OAuth2Settings.TokenURL,
-			Scopes:           []string{},
-			EndpointParams:   url.Values{},
-			AuthStyle:        settings.OAuth2Settings.AuthStyle,
-			TokenType:        settings.OAuth2Settings.TokenType,
-			AuthHeader:       settings.OAuth2Settings.AuthHeader,
-			SkipSpaceInToken: settings.OAuth2Settings.SkipSpaceInToken,
+			ClientID:       settings.OAuth2Settings.ClientID,
+			ClientSecret:   settings.OAuth2Settings.ClientSecret,
+			TokenURL:       settings.OAuth2Settings.TokenURL,
+			Scopes:         []string{},
+			EndpointParams: url.Values{},
+			AuthStyle:      settings.OAuth2Settings.AuthStyle,
+			AuthHeader:     settings.OAuth2Settings.AuthHeader,
+			TokenTemplate:  settings.OAuth2Settings.TokenTemplate,
 		}
 		for _, scope := range settings.OAuth2Settings.Scopes {
 			if scope != "" {
@@ -148,15 +147,14 @@ func applyOAuthJWT(ctx context.Context, httpClient *http.Client, settings models
 	defer span.End()
 	if isOAuthJWTConfigured(settings) {
 		jwtConfig := jwt.Config{
-			Email:            settings.OAuth2Settings.Email,
-			TokenURL:         settings.OAuth2Settings.TokenURL,
-			PrivateKey:       []byte(strings.ReplaceAll(settings.OAuth2Settings.PrivateKey, "\\n", "\n")),
-			PrivateKeyID:     settings.OAuth2Settings.PrivateKeyID,
-			Subject:          settings.OAuth2Settings.Subject,
-			TokenType:        settings.OAuth2Settings.TokenType,
-			AuthHeader:       settings.OAuth2Settings.AuthHeader,
-			SkipSpaceInToken: settings.OAuth2Settings.SkipSpaceInToken,
-			Scopes:           []string{},
+			Email:         settings.OAuth2Settings.Email,
+			TokenURL:      settings.OAuth2Settings.TokenURL,
+			PrivateKey:    []byte(strings.ReplaceAll(settings.OAuth2Settings.PrivateKey, "\\n", "\n")),
+			PrivateKeyID:  settings.OAuth2Settings.PrivateKeyID,
+			Subject:       settings.OAuth2Settings.Subject,
+			AuthHeader:    settings.OAuth2Settings.AuthHeader,
+			TokenTemplate: settings.OAuth2Settings.TokenTemplate,
+			Scopes:        []string{},
 		}
 		for _, scope := range settings.OAuth2Settings.Scopes {
 			if scope != "" {

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -36,17 +36,20 @@ const (
 )
 
 type OAuth2Settings struct {
-	OAuth2Type     string           `json:"oauth2_type,omitempty"`
-	ClientID       string           `json:"client_id,omitempty"`
-	TokenURL       string           `json:"token_url,omitempty"`
-	Email          string           `json:"email,omitempty"`
-	PrivateKeyID   string           `json:"private_key_id,omitempty"`
-	Subject        string           `json:"subject,omitempty"`
-	Scopes         []string         `json:"scopes,omitempty"`
-	AuthStyle      oauth2.AuthStyle `json:"authStyle,omitempty"`
-	ClientSecret   string
-	PrivateKey     string
-	EndpointParams map[string]string
+	OAuth2Type       string           `json:"oauth2_type,omitempty"`
+	ClientID         string           `json:"client_id,omitempty"`
+	TokenURL         string           `json:"token_url,omitempty"`
+	Email            string           `json:"email,omitempty"`
+	PrivateKeyID     string           `json:"private_key_id,omitempty"`
+	Subject          string           `json:"subject,omitempty"`
+	Scopes           []string         `json:"scopes,omitempty"`
+	AuthStyle        oauth2.AuthStyle `json:"authStyle,omitempty"`
+	TokenType        string           `json:"tokenType,omitempty"`
+	AuthHeader       string           `json:"authHeader,omitempty"`
+	SkipSpaceInToken bool             `json:"skipSpaceInToken,omitempty"`
+	ClientSecret     string
+	PrivateKey       string
+	EndpointParams   map[string]string
 }
 
 type AWSAuthType string

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -36,20 +36,19 @@ const (
 )
 
 type OAuth2Settings struct {
-	OAuth2Type       string           `json:"oauth2_type,omitempty"`
-	ClientID         string           `json:"client_id,omitempty"`
-	TokenURL         string           `json:"token_url,omitempty"`
-	Email            string           `json:"email,omitempty"`
-	PrivateKeyID     string           `json:"private_key_id,omitempty"`
-	Subject          string           `json:"subject,omitempty"`
-	Scopes           []string         `json:"scopes,omitempty"`
-	AuthStyle        oauth2.AuthStyle `json:"authStyle,omitempty"`
-	TokenType        string           `json:"tokenType,omitempty"`
-	AuthHeader       string           `json:"authHeader,omitempty"`
-	SkipSpaceInToken bool             `json:"skipSpaceInToken,omitempty"`
-	ClientSecret     string
-	PrivateKey       string
-	EndpointParams   map[string]string
+	OAuth2Type     string           `json:"oauth2_type,omitempty"`
+	ClientID       string           `json:"client_id,omitempty"`
+	TokenURL       string           `json:"token_url,omitempty"`
+	Email          string           `json:"email,omitempty"`
+	PrivateKeyID   string           `json:"private_key_id,omitempty"`
+	Subject        string           `json:"subject,omitempty"`
+	Scopes         []string         `json:"scopes,omitempty"`
+	AuthStyle      oauth2.AuthStyle `json:"authStyle,omitempty"`
+	AuthHeader     string           `json:"authHeader,omitempty"`
+	TokenTemplate  string           `json:"tokenTemplate,omitempty"`
+	ClientSecret   string
+	PrivateKey     string
+	EndpointParams map[string]string
 }
 
 type AWSAuthType string

--- a/pkg/testsuite/handler_querydata_test.go
+++ b/pkg/testsuite/handler_querydata_test.go
@@ -228,14 +228,13 @@ func TestAuthentication(t *testing.T) {
 				AllowedHosts:         []string{server.URL},
 				AuthenticationMethod: models.AuthenticationMethodOAuth,
 				OAuth2Settings: models.OAuth2Settings{
-					OAuth2Type:       models.AuthOAuthTypeClientCredentials,
-					TokenURL:         server.URL + "/token",
-					ClientID:         "MY_CLIENT_ID",
-					ClientSecret:     "MY_CLIENT_SECRET",
-					AuthHeader:       "Auth",
-					TokenType:        "key=",
-					Scopes:           []string{"scope1", "scope2"},
-					SkipSpaceInToken: true,
+					OAuth2Type:    models.AuthOAuthTypeClientCredentials,
+					TokenURL:      server.URL + "/token",
+					ClientID:      "MY_CLIENT_ID",
+					ClientSecret:  "MY_CLIENT_SECRET",
+					AuthHeader:    "Auth",
+					TokenTemplate: "key={{ access_token }}",
+					Scopes:        []string{"scope1", "scope2"},
 				},
 			})
 			require.Nil(t, err)
@@ -272,13 +271,13 @@ func TestAuthentication(t *testing.T) {
 				AllowedHosts:         []string{server.URL},
 				AuthenticationMethod: models.AuthenticationMethodOAuth,
 				OAuth2Settings: models.OAuth2Settings{
-					OAuth2Type:   models.AuthOAuthTypeClientCredentials,
-					TokenURL:     server.URL + "/token",
-					ClientID:     "MY_CLIENT_ID",
-					ClientSecret: "MY_CLIENT_SECRET",
-					AuthHeader:   "Auth",
-					TokenType:    "key=",
-					Scopes:       []string{"scope1", "scope2"},
+					OAuth2Type:    models.AuthOAuthTypeClientCredentials,
+					TokenURL:      server.URL + "/token",
+					ClientID:      "MY_CLIENT_ID",
+					ClientSecret:  "MY_CLIENT_SECRET",
+					AuthHeader:    "Auth",
+					TokenTemplate: "key= {{ access_token }}",
+					Scopes:        []string{"scope1", "scope2"},
 				},
 			})
 			require.Nil(t, err)
@@ -315,12 +314,12 @@ func TestAuthentication(t *testing.T) {
 				AllowedHosts:         []string{server.URL},
 				AuthenticationMethod: models.AuthenticationMethodOAuth,
 				OAuth2Settings: models.OAuth2Settings{
-					OAuth2Type:   models.AuthOAuthTypeClientCredentials,
-					TokenURL:     server.URL + "/token",
-					ClientID:     "MY_CLIENT_ID",
-					ClientSecret: "MY_CLIENT_SECRET",
-					TokenType:    " ",
-					Scopes:       []string{"scope1", "scope2"},
+					OAuth2Type:    models.AuthOAuthTypeClientCredentials,
+					TokenURL:      server.URL + "/token",
+					ClientID:      "MY_CLIENT_ID",
+					ClientSecret:  "MY_CLIENT_SECRET",
+					TokenTemplate: "{{ access_token }}",
+					Scopes:        []string{"scope1", "scope2"},
 				},
 			})
 			require.Nil(t, err)

--- a/src/editors/config/OAuthInput.tsx
+++ b/src/editors/config/OAuthInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { css } from '@emotion/css';
 import { onUpdateDatasourceSecureJsonDataOption, type DataSourcePluginOptionsEditorProps, type SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Input, LegacyForms, LinkButton, RadioButtonGroup, CollapsableSection, Stack, InlineSwitch } from '@grafana/ui';
+import { InlineFormLabel, Input, LegacyForms, LinkButton, RadioButtonGroup, Stack } from '@grafana/ui';
 import { Components } from '@/selectors';
 import { SecureFieldsEditor } from '@/components/config/SecureFieldsEditor';
 import type { InfinityOptions, InfinitySecureOptions, OAuth2Props, OAuth2Type } from '@/types';
@@ -191,12 +192,18 @@ export const OAuthInputsEditor = (props: DataSourcePluginOptionsEditorProps<Infi
 const TokenCustomization = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {
   const { options, onOptionsChange } = props;
   const oauth2: OAuth2Props = options?.jsonData?.oauth2 || {};
-  const { TokenHeader: TokenHeaderSelector, TokenPrefix: TokenPrefixSelector, SkipSpace: SkipSpaceSelector } = Components.ConfigEditor.Auth.OAuth2;
+  const { TokenHeader: TokenHeaderSelector, TokenTemplate: TokenTemplateSelector } = Components.ConfigEditor.Auth.OAuth2;
   const onOAuth2PropsChange = <T extends keyof OAuth2Props, V extends OAuth2Props[T]>(key: T, value: V) => {
     onOptionsChange({ ...options, jsonData: { ...options.jsonData, oauth2: { ...oauth2, [key]: value } } });
   };
+  const styles = {
+    subheading: css`
+      margin-block: 20px;
+    `,
+  };
   return (
-    <CollapsableSection label="Customize auth token (Advanced)" isOpen={true}>
+    <div>
+      <h5 className={styles.subheading}>Customize OAuth2 token (Advanced)</h5>
       <Stack direction={'column'}>
         <Stack gap={0.5}>
           <InlineFormLabel width={12} interactive={true} tooltip={TokenHeaderSelector.tooltip}>
@@ -205,18 +212,12 @@ const TokenCustomization = (props: DataSourcePluginOptionsEditorProps<InfinityOp
           <Input onChange={(v) => onOAuth2PropsChange('authHeader', v.currentTarget.value)} value={oauth2.authHeader} width={30} placeholder={TokenHeaderSelector.placeholder} />
         </Stack>
         <Stack gap={0.5}>
-          <InlineFormLabel width={12} interactive={true} tooltip={TokenPrefixSelector.tooltip}>
-            {TokenPrefixSelector.label}
+          <InlineFormLabel width={12} interactive={true} tooltip={TokenTemplateSelector.tooltip}>
+            {TokenTemplateSelector.label}
           </InlineFormLabel>
-          <Input onChange={(v) => onOAuth2PropsChange('tokenType', v.currentTarget.value)} value={oauth2.tokenType} width={30} placeholder={TokenPrefixSelector.placeholder} />
-        </Stack>
-        <Stack gap={0.5}>
-          <InlineFormLabel width={12} interactive={true} tooltip={SkipSpaceSelector.tooltip}>
-            {SkipSpaceSelector.label}
-          </InlineFormLabel>
-          <InlineSwitch value={oauth2.skipSpaceInToken} onChange={(v) => onOAuth2PropsChange('skipSpaceInToken', v.currentTarget.checked)} />
+          <Input onChange={(v) => onOAuth2PropsChange('tokenTemplate', v.currentTarget.value)} value={oauth2.tokenTemplate} width={30} placeholder={TokenTemplateSelector.placeholder} />
         </Stack>
       </Stack>
-    </CollapsableSection>
+    </div>
   );
 };

--- a/src/editors/config/OAuthInput.tsx
+++ b/src/editors/config/OAuthInput.tsx
@@ -1,6 +1,7 @@
-import { onUpdateDatasourceSecureJsonDataOption, DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
-import { InlineFormLabel, Input, LegacyForms, LinkButton, RadioButtonGroup } from '@grafana/ui';
 import React from 'react';
+import { onUpdateDatasourceSecureJsonDataOption, type DataSourcePluginOptionsEditorProps, type SelectableValue } from '@grafana/data';
+import { InlineFormLabel, Input, LegacyForms, LinkButton, RadioButtonGroup, CollapsableSection, Stack, InlineSwitch } from '@grafana/ui';
+import { Components } from '@/selectors';
 import { SecureFieldsEditor } from '@/components/config/SecureFieldsEditor';
 import type { InfinityOptions, InfinitySecureOptions, OAuth2Props, OAuth2Type } from '@/types';
 
@@ -113,6 +114,7 @@ export const OAuthInputsEditor = (props: DataSourcePluginOptionsEditorProps<Infi
               secureFieldValue="oauth2EndPointParamsValue"
             />
           </div>
+          <TokenCustomization options={options} onOptionsChange={onOptionsChange} />
         </>
       )}
       {oauth2.oauth2_type === 'jwt' && (
@@ -167,6 +169,7 @@ export const OAuthInputsEditor = (props: DataSourcePluginOptionsEditorProps<Infi
               placeholder={'Comma separated values of scopes'}
             />
           </div>
+          <TokenCustomization options={options} onOptionsChange={onOptionsChange} />
         </>
       )}
       {oauth2.oauth2_type === 'others' && (
@@ -182,5 +185,38 @@ export const OAuthInputsEditor = (props: DataSourcePluginOptionsEditorProps<Infi
         </div>
       )}
     </>
+  );
+};
+
+const TokenCustomization = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {
+  const { options, onOptionsChange } = props;
+  const oauth2: OAuth2Props = options?.jsonData?.oauth2 || {};
+  const { TokenHeader: TokenHeaderSelector, TokenPrefix: TokenPrefixSelector, SkipSpace: SkipSpaceSelector } = Components.ConfigEditor.Auth.OAuth2;
+  const onOAuth2PropsChange = <T extends keyof OAuth2Props, V extends OAuth2Props[T]>(key: T, value: V) => {
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, oauth2: { ...oauth2, [key]: value } } });
+  };
+  return (
+    <CollapsableSection label="Customize auth token (Advanced)" isOpen={true}>
+      <Stack direction={'column'}>
+        <Stack gap={0.5}>
+          <InlineFormLabel width={12} interactive={true} tooltip={TokenHeaderSelector.tooltip}>
+            {TokenHeaderSelector.label}
+          </InlineFormLabel>
+          <Input onChange={(v) => onOAuth2PropsChange('authHeader', v.currentTarget.value)} value={oauth2.authHeader} width={30} placeholder={TokenHeaderSelector.placeholder} />
+        </Stack>
+        <Stack gap={0.5}>
+          <InlineFormLabel width={12} interactive={true} tooltip={TokenPrefixSelector.tooltip}>
+            {TokenPrefixSelector.label}
+          </InlineFormLabel>
+          <Input onChange={(v) => onOAuth2PropsChange('tokenType', v.currentTarget.value)} value={oauth2.tokenType} width={30} placeholder={TokenPrefixSelector.placeholder} />
+        </Stack>
+        <Stack gap={0.5}>
+          <InlineFormLabel width={12} interactive={true} tooltip={SkipSpaceSelector.tooltip}>
+            {SkipSpaceSelector.label}
+          </InlineFormLabel>
+          <InlineSwitch value={oauth2.skipSpaceInToken} onChange={(v) => onOAuth2PropsChange('skipSpaceInToken', v.currentTarget.checked)} />
+        </Stack>
+      </Stack>
+    </CollapsableSection>
   );
 };

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -5,6 +5,22 @@ export const Components = {
   Common: {},
   ConfigEditor: {
     Auth: {
+      OAuth2: {
+        TokenHeader: {
+          label: 'Custom Token Header',
+          tooltip: `Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization`,
+          placeholder: 'Authorization',
+        },
+        TokenPrefix: {
+          label: 'Custom Token Prefix',
+          tooltip: `Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer https://datatracker.ietf.org/doc/html/rfc6749#section-7.1 for more details. Defaults to Bearer`,
+          placeholder: 'Bearer',
+        },
+        SkipSpace: {
+          label: 'Skip Space in Token',
+          tooltip: 'If selected, space between token prefix and token will be skipped',
+        },
+      },
       AzureBlob: {
         Region: {
           label: 'Azure cloud',

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -11,14 +11,10 @@ export const Components = {
           tooltip: `Once the token retrieved, the same will be sent to subsequent request's header with the key "Authorization". If the API require different key, provide the key here. Defaults to Authorization`,
           placeholder: 'Authorization',
         },
-        TokenPrefix: {
-          label: 'Custom Token Prefix',
-          tooltip: `Once the token retrieved, the same will be sent to subsequent request's Authorization header with the prefix "Bearer " or whatever returned from the initial token retrieval request's response. If the API require different prefix, provide the prefix here. Refer https://datatracker.ietf.org/doc/html/rfc6749#section-7.1 for more details. Defaults to Bearer`,
-          placeholder: 'Bearer',
-        },
-        SkipSpace: {
-          label: 'Skip Space in Token',
-          tooltip: 'If selected, space between token prefix and token will be skipped',
+        TokenTemplate: {
+          label: 'Custom Token Template',
+          tooltip: `Token Template allows you to customize the token value using the template. This will be Authorization header value. String {{ access_token }} will be replaced with actual access token`,
+          placeholder: 'Bearer {{ access_token }}',
         },
       },
       AzureBlob: {

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -19,9 +19,8 @@ export type OAuth2Props = {
   token_url?: string;
   scopes?: string[];
   authStyle?: number;
-  tokenType?: string;
   authHeader?: string;
-  skipSpaceInToken?: boolean;
+  tokenTemplate?: string;
 };
 export type AWSAuthProps = {
   authType?: 'keys';

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -19,6 +19,9 @@ export type OAuth2Props = {
   token_url?: string;
   scopes?: string[];
   authStyle?: number;
+  tokenType?: string;
+  authHeader?: string;
+  skipSpaceInToken?: boolean;
 };
 export type AWSAuthProps = {
   authType?: 'keys';


### PR DESCRIPTION
This PR allows you to setup custom token formats in OAuth2 type authentication.

Core changes are in OAuth2 fork https://github.com/grafana/oauth2/compare/master...grafana:oauth2:custom-token-type

This PR only pass the required props to the underlying OAuth2 library. 

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/0d86087d-c30c-499e-8aeb-2812961d7d0a" />

## Other changes in PR

* Go lang version bumped to 1.24.4
* Updated outdated contributing / installation docs with latest version references

