### PR TITLE
Update to Go 1.24.4

### DIFF
--- a/.changeset/slimy-bikes-type.md
+++ b/.changeset/slimy-bikes-type.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Upgrade GO to 1.24.4 to address CVE 2025-4673 and more.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main
     with:
-      go-version: '1.24.3'
+      go-version: '1.24.4'
       golangci-lint-version: '1.64.6'
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
     name: CI
     uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main
     with:
-      go-version: '1.24.3'
+      go-version: '1.24.4'
       golangci-lint-version: '1.64.6'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-infinity-datasource
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-infinity-datasource",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "JSON, CSV, XML, GraphQL, HTML and REST API datasource for Grafana. Do infinite things with Grafana. Transform data with UQL/GROQ. Visualize data from many apis, RSS/ATOM feeds directly",
   "keywords": [
     "grafana",


### PR DESCRIPTION
Address CVE 2025-4673 and more. 

https://github.com/golang/go/issues?q=milestone%3AGo1.24.4+label%3ACherryPickApproved