### PR TITLE
Chore: removes props mutations

### DIFF
--- a/src/editors/query/query.computedColumns.test.tsx
+++ b/src/editors/query/query.computedColumns.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ComputedColumnsEditor } from './query.computedColumns';
+import type { InfinityColumn, InfinityColumnFormat, InfinityQuery, InfinityQueryFormat, InfinityURLOptions } from '../../types';
+
+describe('ComputedColumnsEditor', () => {
+  // Freezing the object so that any mutations throw errors
+  const mockQuery: InfinityQuery = Object.freeze({
+    refId: 'A',
+    type: 'json',
+    source: 'url',
+    url: 'http://example.com',
+    parser: 'backend',
+    columns: [],
+    format: 'table' as InfinityQueryFormat,
+    root_selector: '',
+    url_options: {} as InfinityURLOptions,
+    computed_columns: Object.freeze([
+      {
+        text: 'Column 1',
+        selector: '$.name',
+        type: 'string' as InfinityColumnFormat,
+      },
+      {
+        text: 'Column 2',
+        selector: '$.value',
+        type: 'number' as InfinityColumnFormat,
+      },
+    ]) as InfinityColumn[],
+  });
+
+  const mockOnChange = jest.fn();
+  const mockOnRunQuery = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Removing computed columns', () => {
+    it('should remove a computed column when clicking the trash button', async () => {
+      render(<ComputedColumnsEditor query={mockQuery} onChange={mockOnChange} onRunQuery={mockOnRunQuery} />);
+
+      // Find and click the trash button for the first computed column
+      const deleteButtons = screen.getAllByTestId('trash-alt');
+      await userEvent.click(deleteButtons[0]);
+
+      // Verify onChange was called with the first computed column removed
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...mockQuery,
+          computed_columns: [
+            {
+              text: 'Column 2',
+              selector: '$.value',
+              type: 'number',
+            },
+          ],
+        })
+      );
+    });
+
+    it('should remove all computed columns when clicking trash buttons on all items', async () => {
+      const queryWithSingleColumn: InfinityQuery = Object.freeze({
+        ...mockQuery,
+        computed_columns: Object.freeze([
+          {
+            text: 'Single Column',
+            selector: '$.single',
+            type: 'string' as InfinityColumnFormat,
+          },
+        ]) as InfinityColumn[],
+      });
+
+      render(<ComputedColumnsEditor query={queryWithSingleColumn} onChange={mockOnChange} onRunQuery={mockOnRunQuery} />);
+
+      // Click the trash button to remove the single computed column
+      const deleteButton = screen.getByTestId('trash-alt');
+      await userEvent.click(deleteButton);
+
+      // Verify onChange was called with empty computed_columns array
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...queryWithSingleColumn,
+          computed_columns: [],
+        })
+      );
+    });
+  });
+});

--- a/src/editors/query/query.computedColumns.tsx
+++ b/src/editors/query/query.computedColumns.tsx
@@ -13,8 +13,8 @@ export const ComputedColumnsEditor = (props: { query: InfinityQuery; onChange: (
       onChange({ ...query, computed_columns: [...columns, defaultColumn] });
     };
     const onComputedColumnRemove = (index: number) => {
-      const computed_columns = query?.computed_columns || [];
-      computed_columns.splice(index, 1);
+      const computedColumns = query?.computed_columns || [];
+      const computed_columns = computedColumns.filter((_, i) => i !== index);
       onChange({ ...query, computed_columns });
     };
     return (

--- a/src/editors/query/query.series.test.tsx
+++ b/src/editors/query/query.series.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { SeriesAdvancedOptions } from './query.series';
+import type { DataOverride, InfinitySeriesQuery } from '../../types';
+
+describe('SeriesAdvancedOptions', () => {
+  // Freezing the object so that any mutations throw errors
+  const mockQuery: InfinitySeriesQuery = Object.freeze({
+    refId: 'A',
+    type: 'series',
+    source: 'random-walk',
+    seriesCount: 1,
+    alias: 'Test Series',
+    dataOverrides: Object.freeze([]) as unknown as DataOverride[],
+  });
+
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Adding data overrides', () => {
+    it('should add a new data override when clicking "Click to add Overrides"', async () => {
+      render(<SeriesAdvancedOptions query={mockQuery} onChange={mockOnChange} />);
+
+      // Open the modal
+      const advancedButton = screen.getByText('Advanced Options');
+      await userEvent.click(advancedButton);
+
+      // Click to add override
+      const addOverrideButton = screen.getByText('Click to add Overrides');
+      await userEvent.click(addOverrideButton);
+
+      // Verify onChange was called with the new data override
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...mockQuery,
+          dataOverrides: [
+            {
+              values: ['${__value.index}', '10'],
+              operator: '>=',
+              override: 'null',
+            },
+          ],
+        })
+      );
+    });
+
+    it('should add a new data override when clicking the "+" button', async () => {
+      const queryWithExistingOverride: InfinitySeriesQuery = Object.freeze({
+        ...mockQuery,
+        dataOverrides: Object.freeze([
+          {
+            values: ['test1', 'test2'],
+            operator: '=',
+            override: 'test-override',
+          },
+        ]) as unknown as DataOverride[],
+      });
+
+      render(<SeriesAdvancedOptions query={queryWithExistingOverride} onChange={mockOnChange} />);
+
+      // Open the modal
+      const advancedButton = screen.getByText('Advanced Options');
+      await userEvent.click(advancedButton);
+
+      // Click the "+" button to add another override
+      const addButton = screen.getByText('+');
+      await userEvent.click(addButton);
+
+      // Verify onChange was called with the additional data override
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...queryWithExistingOverride,
+          dataOverrides: [
+            {
+              values: ['test1', 'test2'],
+              operator: '=',
+              override: 'test-override',
+            },
+            {
+              values: ['${__value.index}', '10'],
+              operator: '>=',
+              override: 'null',
+            },
+          ],
+        })
+      );
+    });
+  });
+
+  describe('Deleting data overrides', () => {
+    it('should remove a data override when clicking the "X" button', async () => {
+      // Freezing the object so that any mutations throw errors
+      const queryWithOverrides: InfinitySeriesQuery = Object.freeze({
+        ...mockQuery,
+        dataOverrides: Object.freeze([
+          {
+            values: ['test1', 'test2'],
+            operator: '=',
+            override: 'test-override',
+          },
+          {
+            values: ['test3', 'test4'],
+            operator: '!=',
+            override: 'another-override',
+          },
+        ]) as unknown as DataOverride[],
+      });
+
+      render(<SeriesAdvancedOptions query={queryWithOverrides} onChange={mockOnChange} />);
+
+      // Open the modal
+      const advancedButton = screen.getByText('Advanced Options');
+      await userEvent.click(advancedButton);
+
+      // Find and click the "X" button for the first override
+      const deleteButtons = screen.getAllByText('X');
+      await userEvent.click(deleteButtons[0]);
+
+      // Verify onChange was called with the first override removed
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...queryWithOverrides,
+          dataOverrides: [
+            {
+              values: ['test3', 'test4'],
+              operator: '!=',
+              override: 'another-override',
+            },
+          ],
+        })
+      );
+    });
+
+    it('should remove all data overrides when clicking "X" on all items', async () => {
+      // Freezing the object so that any mutations throw errors
+      const queryWithOverrides: InfinitySeriesQuery = Object.freeze({
+        ...mockQuery,
+        dataOverrides: Object.freeze([
+          {
+            values: ['test1', 'test2'],
+            operator: '=',
+            override: 'test-override',
+          },
+        ]) as unknown as DataOverride[],
+      });
+
+      render(<SeriesAdvancedOptions query={queryWithOverrides} onChange={mockOnChange} />);
+
+      // Open the modal
+      const advancedButton = screen.getByText('Advanced Options');
+      await userEvent.click(advancedButton);
+
+      // Click the "X" button to remove the override
+      const deleteButton = screen.getByText('X');
+      await userEvent.click(deleteButton);
+
+      // Verify onChange was called with empty dataOverrides array
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...queryWithOverrides,
+          dataOverrides: [],
+        })
+      );
+    });
+  });
+});

--- a/src/editors/query/query.series.tsx
+++ b/src/editors/query/query.series.tsx
@@ -51,7 +51,8 @@ export const SeriesEditor = ({ query, onChange }: { query: InfinitySeriesQuery; 
   );
 };
 
-const SeriesAdvancedOptions = ({ query, onChange }: { query: InfinitySeriesQuery; onChange: (value: any) => void }) => {
+// exported for testing purposes only
+export const SeriesAdvancedOptions = ({ query, onChange }: { query: InfinitySeriesQuery; onChange: (value: any) => void }) => {
   query = defaultsDeep(query, {
     dataOverrides: [],
   });
@@ -66,19 +67,19 @@ const SeriesAdvancedOptions = ({ query, onChange }: { query: InfinitySeriesQuery
   });
 
   const addDataOverride = () => {
-    query.dataOverrides = query.dataOverrides || [];
+    const queryDataOverrides = query.dataOverrides || [];
     let newOverride: DataOverride = {
       values: ['${__value.index}', '10'],
       operator: '>=',
       override: 'null',
     };
-    query.dataOverrides.push(newOverride);
-    onChange(query);
+    const dataOverrides = queryDataOverrides.concat(newOverride);
+    onChange({ ...query, dataOverrides });
   };
   const removeDataOverride = (index: number) => {
-    query.dataOverrides = query.dataOverrides || [];
-    query.dataOverrides.splice(index, 1);
-    onChange(query);
+    const queryDataOverrides = query.dataOverrides || [];
+    const dataOverrides = queryDataOverrides.filter((_, i) => i !== index);
+    onChange({ ...query, dataOverrides });
   };
 
   const onTextChange = (value: string, field: string) => {


### PR DESCRIPTION
While investigating this https://ops.grafana-ops.net/goto/19XH_8PNg?orgId=1 I found a couple of props mutations using [`splice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) function. I added some tests that fail with the previous mutating code but work with the new code that doesn't mutate the props.

![image](https://github.com/user-attachments/assets/82e0b660-d474-4124-8214-257b50b9a081)

https://react.dev/reference/rules/components-and-hooks-must-be-pure#props

