### PR TITLE
fixed pagination error in jq backend  parser

### DIFF
--- a/.changeset/lucky-zoos-grin.md
+++ b/.changeset/lucky-zoos-grin.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fixed a bug where pagination not working with jq backend parser


### PR DESCRIPTION
Fixed a bug where pagination not handled with jq backend parser.

## How to test

### Before

```sh
git checkout main
yarn
yarn build
mage -v
docker compose up
```

visit [explorer](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22phj%22:%7B%22datasource%22:%22Infinity%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22yesoreyeram-infinity-datasource%22,%22uid%22:%22Infinity%22%7D,%22type%22:%22json%22,%22source%22:%22url%22,%22format%22:%22table%22,%22url%22:%22https:%2F%2Fpokeapi.co%2Fapi%2Fv2%2Fberry%3Flimit%3D2%22,%22url_options%22:%7B%22method%22:%22GET%22,%22data%22:%22%22%7D,%22root_selector%22:%22.results%22,%22columns%22:%5B%5D,%22filters%22:%5B%5D,%22global_query_id%22:%22%22,%22parser%22:%22jq-backend%22,%22pagination_mode%22:%22offset%22,%22pagination_param_size_field_name%22:%22limit%22,%22pagination_param_size_value%22:2,%22pagination_param_offset_field_name%22:%22offset%22,%22pagination_param_offset_value%22:0,%22pagination_max_pages%22:3%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) and you will see only 2 results with pagination

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/e1897ab3-2a7c-4054-954b-00ef691581ea" />

## After

```sh
git checkout bugfix/jq-pagination
yarn
yarn build
mage -v
docker compose up
```

visit [explorer](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22phj%22:%7B%22datasource%22:%22Infinity%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22yesoreyeram-infinity-datasource%22,%22uid%22:%22Infinity%22%7D,%22type%22:%22json%22,%22source%22:%22url%22,%22format%22:%22table%22,%22url%22:%22https:%2F%2Fpokeapi.co%2Fapi%2Fv2%2Fberry%3Flimit%3D2%22,%22url_options%22:%7B%22method%22:%22GET%22,%22data%22:%22%22%7D,%22root_selector%22:%22.results%22,%22columns%22:%5B%5D,%22filters%22:%5B%5D,%22global_query_id%22:%22%22,%22parser%22:%22jq-backend%22,%22pagination_mode%22:%22offset%22,%22pagination_param_size_field_name%22:%22limit%22,%22pagination_param_size_value%22:2,%22pagination_param_offset_field_name%22:%22offset%22,%22pagination_param_offset_value%22:0,%22pagination_max_pages%22:3%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) and you will see only 2 results with pagination

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/43e43af9-2751-4a62-ab76-d01fdb1155e8" />
