### PR TITLE
Fix: bump grafana-aws-sdk for PDC fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/grafana/dskit v0.0.0-20250306142006-a53bcf294bdf
-	github.com/grafana/grafana-aws-sdk v1.0.2
+	github.com/grafana/grafana-aws-sdk v1.0.4
 	github.com/grafana/grafana-plugin-sdk-go v0.278.0
 	github.com/grafana/infinity-libs/lib/go/csvframer v1.0.3
 	github.com/grafana/infinity-libs/lib/go/framesql v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/dskit v0.0.0-20250306142006-a53bcf294bdf h1:KDyUwD73SH4haZs8psNE3K8yNlxKHsYQw0iq96rukOI=
 github.com/grafana/dskit v0.0.0-20250306142006-a53bcf294bdf/go.mod h1:XG+m+dyFETjmwcds1Sde6L0KQvtUUfvjs+n7MdrTrAM=
-github.com/grafana/grafana-aws-sdk v1.0.2 h1:98eBuHYFmgvH0xO9kKf4RBsEsgQRp8EOA/9yhDIpkss=
-github.com/grafana/grafana-aws-sdk v1.0.2/go.mod h1:hO7q7yWV+t6dmiyJjMa3IbuYnYkBua+G/IAlOPVIYKE=
+github.com/grafana/grafana-aws-sdk v1.0.4 h1:D14UAehsOqpjliHmHzveRQ1p43KCsMzdmb7GovWj+SY=
+github.com/grafana/grafana-aws-sdk v1.0.4/go.mod h1:hO7q7yWV+t6dmiyJjMa3IbuYnYkBua+G/IAlOPVIYKE=
 github.com/grafana/grafana-plugin-sdk-go v0.278.0 h1:5/rIYparLi02pofdaag8wnjspMMVNCi8cZhC4cdC3Ho=
 github.com/grafana/grafana-plugin-sdk-go v0.278.0/go.mod h1:+8NXT/XUJ/89GV6FxGQ366NZ3nU+cAXDMd0OUESF9H4=
 github.com/grafana/infinity-libs/lib/go/csvframer v1.0.3 h1:Vr1Iy2+VDe5Vkx3kLaNbUGVYvpdWqBiYg/BjSkCzPYg=


### PR DESCRIPTION
This updates the version of grafana-aws-sdk to bring in fixes from these PRs: https://github.com/grafana/grafana-aws-sdk/pull/267, https://github.com/grafana/grafana-aws-sdk/pull/269.