### PR TITLE
Chore: fix some more React props mutations

### DIFF
--- a/src/components/ComputedColumn.test.tsx
+++ b/src/components/ComputedColumn.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ComputedColumn } from './ComputedColumn';
+import type { InfinityColumn, InfinityColumnFormat, InfinityQuery, InfinityQueryFormat, InfinityURLOptions } from '../types';
+
+describe('ComputedColumn', () => {
+  // Freezing the object so that any mutations throw errors
+  const mockQuery: InfinityQuery = Object.freeze({
+    refId: 'A',
+    type: 'json',
+    source: 'url',
+    url: 'http://example.com',
+    parser: 'backend',
+    columns: [],
+    format: 'table' as InfinityQueryFormat,
+    root_selector: '',
+    url_options: {} as InfinityURLOptions,
+    computed_columns: Object.freeze([
+      Object.freeze({
+        text: 'Column 1',
+        selector: '$.name',
+        type: 'string' as InfinityColumnFormat,
+      }),
+      Object.freeze({
+        text: 'Column 2',
+        selector: '$.value',
+        type: 'number' as InfinityColumnFormat,
+      }),
+    ]) as InfinityColumn[],
+  });
+
+  const mockOnChange = jest.fn();
+  const mockOnRunQuery = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onExpressionChange', () => {
+    it('should update the selector and call onChange and onRunQuery when expression input loses focus', async () => {
+      render(<ComputedColumn query={mockQuery} onChange={mockOnChange} onRunQuery={mockOnRunQuery} index={0} />);
+
+      const expressionInput = screen.getByPlaceholderText('Expression');
+      await userEvent.clear(expressionInput);
+      await userEvent.type(expressionInput, '$.newSelector');
+      await userEvent.tab(); // Trigger onBlur
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...mockQuery,
+        computed_columns: [
+          {
+            text: 'Column 1',
+            selector: '$.newSelector',
+            type: 'string',
+          },
+          {
+            text: 'Column 2',
+            selector: '$.value',
+            type: 'number',
+          },
+        ],
+      });
+      expect(mockOnRunQuery).toHaveBeenCalled();
+    });
+
+    it('should update the correct computed column based on index', async () => {
+      render(<ComputedColumn query={mockQuery} onChange={mockOnChange} onRunQuery={mockOnRunQuery} index={1} />);
+
+      const expressionInput = screen.getByPlaceholderText('Expression');
+      await userEvent.clear(expressionInput);
+      await userEvent.type(expressionInput, '$.updatedValue');
+      await userEvent.tab(); // Trigger onBlur
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...mockQuery,
+        computed_columns: [
+          {
+            text: 'Column 1',
+            selector: '$.name',
+            type: 'string',
+          },
+          {
+            text: 'Column 2',
+            selector: '$.updatedValue',
+            type: 'number',
+          },
+        ],
+      });
+      expect(mockOnRunQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe('onAliasChange', () => {
+    it('should update the text and call onChange and onRunQuery when alias input loses focus', async () => {
+      render(<ComputedColumn query={mockQuery} onChange={mockOnChange} onRunQuery={mockOnRunQuery} index={0} />);
+
+      const aliasInput = screen.getByPlaceholderText('Title');
+      await userEvent.clear(aliasInput);
+      await userEvent.type(aliasInput, 'New Column Name');
+      await userEvent.tab(); // Trigger onBlur
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...mockQuery,
+        computed_columns: [
+          {
+            text: 'New Column Name',
+            selector: '$.name',
+            type: 'string',
+          },
+          {
+            text: 'Column 2',
+            selector: '$.value',
+            type: 'number',
+          },
+        ],
+      });
+      expect(mockOnRunQuery).toHaveBeenCalled();
+    });
+
+    it('should update the correct computed column alias based on index', async () => {
+      render(<ComputedColumn query={mockQuery} onChange={mockOnChange} onRunQuery={mockOnRunQuery} index={1} />);
+
+      const aliasInput = screen.getByPlaceholderText('Title');
+      await userEvent.clear(aliasInput);
+      await userEvent.type(aliasInput, 'Updated Value Column');
+      await userEvent.tab(); // Trigger onBlur
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        ...mockQuery,
+        computed_columns: [
+          {
+            text: 'Column 1',
+            selector: '$.name',
+            type: 'string',
+          },
+          {
+            text: 'Updated Value Column',
+            selector: '$.value',
+            type: 'number',
+          },
+        ],
+      });
+      expect(mockOnRunQuery).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ComputedColumn.tsx
+++ b/src/components/ComputedColumn.tsx
@@ -18,14 +18,14 @@ export const ComputedColumn = (props: ComputedColumnProps) => {
   if ((query.type === 'json' || query.type === 'graphql' || query.type === 'csv' || query.type === 'tsv') && query.parser === 'backend') {
     const onExpressionChange = () => {
       const computedColumns = query?.computed_columns || [];
-      computedColumns[index].selector = expression;
-      onChange({ ...query, computed_columns: computedColumns });
+      const updatedComputedColumns = computedColumns.map((col, i) => (i === index ? { ...col, selector: expression } : col));
+      onChange({ ...query, computed_columns: updatedComputedColumns });
       onRunQuery();
     };
     const onAliasChange = () => {
       const computed_columns = query?.computed_columns || [];
-      computed_columns[index].text = alias;
-      onChange({ ...query, computed_columns });
+      const updatedComputedColumns = computed_columns.map((col, i) => (i === index ? { ...col, text: alias } : col));
+      onChange({ ...query, computed_columns: updatedComputedColumns });
       onRunQuery();
     };
     return (

--- a/src/editors/config.editor.test.tsx
+++ b/src/editors/config.editor.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { InfinityOptions } from '@/types';
+import { InfinityConfigEditor } from './config.editor';
+
+// Mock react-router-dom Link component
+jest.mock('react-router-dom', () => ({
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+describe('InfinityConfigEditor', () => {
+  const mockOnOptionsChange = jest.fn();
+
+  // Freezing the object so that any mutations throw errors
+  const mockProps: DataSourcePluginOptionsEditorProps<InfinityOptions> = Object.freeze({
+    onOptionsChange: mockOnOptionsChange,
+    options: {
+      id: 1,
+      access: '',
+      basicAuth: false,
+      basicAuthUser: '',
+      database: '',
+      isDefault: false,
+      jsonData: Object.freeze({ auth_method: 'apiKey' }),
+      name: '',
+      orgId: 1,
+      readOnly: false,
+      secureJsonFields: Object.freeze({}),
+      type: '',
+      typeLogoUrl: '',
+      typeName: '',
+      uid: '',
+      url: '',
+      user: '',
+      withCredentials: false,
+      secureJsonData: Object.freeze({}),
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not mutate props with defaults', () => {
+    const props = Object.freeze({ ...mockProps });
+
+    // This would previously crash as the component mutated props
+    render(<InfinityConfigEditor {...props} />);
+
+    expect(mockProps.options.jsonData.global_queries).toBeUndefined();
+    expect(props.options.jsonData.global_queries).toBeUndefined();
+    expect(mockOnOptionsChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/editors/config.editor.tsx
+++ b/src/editors/config.editor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { defaultsDeep } from 'lodash';
+import { cloneDeep, defaultsDeep } from 'lodash';
 import { css } from '@emotion/css';
 import { InlineFormLabel, Input, Button, LinkButton, useTheme2, Collapse as CollapseOriginal, Stack, Grid } from '@grafana/ui';
 import { SecureFieldsEditor } from '@/components/config/SecureFieldsEditor';
@@ -150,7 +150,7 @@ const config_sections: Array<{ value: string; label: string }> = [
 ];
 
 const getOptionsWithDefaults = (options: DataSourceSettings<InfinityOptions>) => {
-  return { ...options, jsonData: defaultsDeep(options.jsonData, { global_queries: [] }) };
+  return { ...options, jsonData: defaultsDeep(cloneDeep(options.jsonData), { global_queries: [] }) };
 };
 
 export const InfinityConfigEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {

--- a/src/editors/query.editor.test.tsx
+++ b/src/editors/query.editor.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, within } from '@testing-library/react';
+import { QueryEditorProps } from '@grafana/data';
+import { Datasource } from '@/datasource';
+import { InfinityQuery, InfinityQueryFormat } from '@/types';
+import { QueryEditor } from './query.editor';
+
+// Mock react-router-dom Link component
+jest.mock('react-router-dom', () => ({
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+describe('QueryEditor', () => {
+  const mockQuery: InfinityQuery = Object.freeze({
+    refId: 'A',
+    type: 'csv',
+    source: 'url',
+    url: 'http://example.com',
+    parser: 'simple',
+    format: 'node-graph-nodes' as InfinityQueryFormat,
+    root_selector: '',
+  }) as InfinityQuery;
+
+  const mockOnChange = jest.fn();
+  const mockOnRunQuery = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not mutate props with defaults', () => {
+    const props: QueryEditorProps<Datasource, InfinityQuery> = Object.freeze({
+      query: Object.freeze({ ...mockQuery }),
+      onChange: mockOnChange,
+      onRunQuery: mockOnRunQuery,
+      datasource: Object.freeze({ instanceSettings: Object.freeze({ jsonData: Object.freeze({}) }) }) as Datasource,
+    });
+
+    // This would previously crash as the component mutated props
+    const { getByTestId } = render(<QueryEditor {...props} />);
+
+    // Verify that mockQuery.type shows up in UI
+    const typeField = getByTestId('infinity-query-field-wrapper-type');
+    expect(within(typeField).getByText(/^CSV$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.parser shows up in UI
+    const parserField = getByTestId('infinity-query-field-wrapper-parser');
+    expect(within(parserField).getByText(/^Frontend$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.format shows up in UI
+    const formatField = getByTestId('infinity-query-field-wrapper-format');
+    expect(within(formatField).getByText(/^Nodes - Node Graph$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.url_options shows up in UI
+    const methodField = getByTestId('infinity-query-field-wrapper-method');
+    expect(within(methodField).getByText(/^GET$/)).toBeInTheDocument();
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(mockOnRunQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/editors/query.editor.tsx
+++ b/src/editors/query.editor.tsx
@@ -1,4 +1,4 @@
-import { defaultsDeep } from 'lodash';
+import { cloneDeep, defaultsDeep } from 'lodash';
 import React from 'react';
 import { getDefaultGlobalQueryID } from '@/app/queryUtils';
 import { DefaultInfinityQuery } from '@/constants';
@@ -9,7 +9,7 @@ import type { QueryEditorProps } from '@grafana/data';
 
 export const QueryEditor = (props: QueryEditorProps<Datasource, InfinityQuery>) => {
   const { datasource, onChange, onRunQuery } = props;
-  const query = defaultsDeep(props.query, {
+  const query = defaultsDeep(cloneDeep(props.query), {
     ...DefaultInfinityQuery,
     global_query_id: getDefaultGlobalQueryID(datasource.instanceSettings),
   });

--- a/src/editors/query/infinityQuery.test.tsx
+++ b/src/editors/query/infinityQuery.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, within } from '@testing-library/react';
+import { EditorMode, InfinityQuery, InfinityQueryFormat } from '@/types';
+import { InfinityEditorProps, InfinityQueryEditor } from './infinityQuery';
+import { Datasource } from '@/datasource';
+
+// Mock react-router-dom Link component
+jest.mock('react-router-dom', () => ({
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+describe('InfinityQueryEditor', () => {
+  // Freezing the object so that any mutations throw errors
+  const mockQuery: InfinityQuery = Object.freeze({
+    refId: 'A',
+    type: 'csv',
+    source: 'url',
+    url: 'http://example.com',
+    parser: 'simple',
+    format: 'node-graph-nodes' as InfinityQueryFormat,
+    root_selector: '',
+  }) as InfinityQuery;
+
+  const mockOnChange = jest.fn();
+  const mockOnRunQuery = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not mutate props with defaults', () => {
+    const props: InfinityEditorProps = Object.freeze({
+      query: Object.freeze({ ...mockQuery }),
+      onChange: mockOnChange,
+      onRunQuery: mockOnRunQuery,
+      instanceSettings: Object.freeze({ jsonData: Object.freeze({}) }),
+      mode: 'standard' as EditorMode,
+      datasource: Object.freeze({}) as Datasource,
+    });
+
+    // This would previously crash as the component mutated props
+    const { getByTestId } = render(<InfinityQueryEditor {...props} />);
+
+    // Verify that mockQuery.type shows up in UI
+    const typeField = getByTestId('infinity-query-field-wrapper-type');
+    expect(within(typeField).getByText(/^CSV$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.parser shows up in UI
+    const parserField = getByTestId('infinity-query-field-wrapper-parser');
+    expect(within(parserField).getByText(/^Frontend$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.format shows up in UI
+    const formatField = getByTestId('infinity-query-field-wrapper-format');
+    expect(within(formatField).getByText(/^Nodes - Node Graph$/)).toBeInTheDocument();
+
+    // Verify that mockQuery.url_options shows up in UI
+    const methodField = getByTestId('infinity-query-field-wrapper-method');
+    expect(within(methodField).getByText(/^GET$/)).toBeInTheDocument();
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(mockOnRunQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/editors/query/infinityQuery.tsx
+++ b/src/editors/query/infinityQuery.tsx
@@ -1,4 +1,4 @@
-import { defaultsDeep } from 'lodash';
+import { cloneDeep, defaultsDeep } from 'lodash';
 import React, { useState } from 'react';
 import { EditorRows, EditorRow } from '@/components/extended/EditorRow';
 import { DefaultInfinityQuery } from '@/constants';
@@ -33,7 +33,7 @@ export const InfinityQueryEditor = (props: InfinityEditorProps) => {
   const { onChange, mode, instanceSettings, onRunQuery, datasource } = props;
   const [showUrlOptions, setShowUrlOptions] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  let query: InfinityQuery = defaultsDeep(props.query, DefaultInfinityQuery) as InfinityQuery;
+  let query: InfinityQuery = defaultsDeep(cloneDeep(props.query), DefaultInfinityQuery) as InfinityQuery;
   query = migrateQuery(query);
   let canShowColumnsEditor = ['csv', 'tsv', 'html', 'json', 'graphql', 'xml', 'google-sheets'].includes(query.type);
   let canShowFilterEditor =

--- a/src/editors/query/query.computedColumns.test.tsx
+++ b/src/editors/query/query.computedColumns.test.tsx
@@ -17,16 +17,16 @@ describe('ComputedColumnsEditor', () => {
     root_selector: '',
     url_options: {} as InfinityURLOptions,
     computed_columns: Object.freeze([
-      {
+      Object.freeze({
         text: 'Column 1',
         selector: '$.name',
         type: 'string' as InfinityColumnFormat,
-      },
-      {
+      }),
+      Object.freeze({
         text: 'Column 2',
         selector: '$.value',
         type: 'number' as InfinityColumnFormat,
-      },
+      }),
     ]) as InfinityColumn[],
   });
 

--- a/src/editors/query/query.series.test.tsx
+++ b/src/editors/query/query.series.test.tsx
@@ -85,11 +85,11 @@ describe('SeriesAdvancedOptions', () => {
       const queryWithExistingOverride: InfinitySeriesQuery = Object.freeze({
         ...mockQuery,
         dataOverrides: Object.freeze([
-          {
+          Object.freeze({
             values: ['test1', 'test2'],
             operator: '=',
             override: 'test-override',
-          },
+          }),
         ]) as unknown as DataOverride[],
       });
 
@@ -130,16 +130,16 @@ describe('SeriesAdvancedOptions', () => {
       const queryWithOverrides: InfinitySeriesQuery = Object.freeze({
         ...mockQuery,
         dataOverrides: Object.freeze([
-          {
+          Object.freeze({
             values: ['test1', 'test2'],
             operator: '=',
             override: 'test-override',
-          },
-          {
+          }),
+          Object.freeze({
             values: ['test3', 'test4'],
             operator: '!=',
             override: 'another-override',
-          },
+          }),
         ]) as unknown as DataOverride[],
       });
 
@@ -173,11 +173,11 @@ describe('SeriesAdvancedOptions', () => {
       const queryWithOverrides: InfinitySeriesQuery = Object.freeze({
         ...mockQuery,
         dataOverrides: Object.freeze([
-          {
+          Object.freeze({
             values: ['test1', 'test2'],
             operator: '=',
             override: 'test-override',
-          },
+          }),
         ]) as unknown as DataOverride[],
       });
 


### PR DESCRIPTION
While investigating this https://ops.grafana-ops.net/goto/8__2ZDuHR?orgId=1 I found a couple of props mutations using `defaultDeeps` function from `lodash`. According to `lodash` docs that function mutates the objects.

<img width="1887" height="568" alt="image" src="https://github.com/user-attachments/assets/1681e9b5-76ca-4305-bc9e-5993b3a5b53c" />

I also found some other mutations in `src/components/ComputedColumn.tsx`. I wrote tests before each fix to make sure I had broken tests before I fixed the mutating code.
