### PR TITLE
chore(go): upgrade to version 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-infinity-datasource
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1


### PR DESCRIPTION
For CVE
https://github.com/advisories/GHSA-wprm-fgrx-xj42
https://github.com/advisories/GHSA-j5pm-7495-qmr3