### PR TITLE
test: mock Link components from react-router-dom and @grafana/ui to resolve Router context issues

### DIFF
--- a/src/editors/config.editor.test.tsx
+++ b/src/editors/config.editor.test.tsx
@@ -6,6 +6,13 @@ import { InfinityConfigEditor } from './config.editor';
 
 // Mock react-router-dom Link component
 jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+// Mock @grafana/ui Link component to avoid Router context issues
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
   Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }));
 

--- a/src/editors/query.editor.test.tsx
+++ b/src/editors/query.editor.test.tsx
@@ -7,6 +7,13 @@ import { QueryEditor } from './query.editor';
 
 // Mock react-router-dom Link component
 jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+// Mock @grafana/ui Link component to avoid Router context issues
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
   Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }));
 

--- a/src/editors/query/infinityQuery.test.tsx
+++ b/src/editors/query/infinityQuery.test.tsx
@@ -6,6 +6,13 @@ import { Datasource } from '@/datasource';
 
 // Mock react-router-dom Link component
 jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+// Mock @grafana/ui Link component to avoid Router context issues
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
   Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }));
 


### PR DESCRIPTION
The failing tests were trying to render components that contained Link components from @grafana/ui, which internally use useContext from React Router, but no Router provider was available in the test environment.