### PR TITLE
fix(models): fallback to top-level method field if url_options.method is empty

### DIFF
--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -215,7 +215,11 @@ func ApplyDefaultsToQuery(ctx context.Context, pCtx *backend.PluginContext, quer
 		}
 	}
 	if query.Source == "url" && strings.TrimSpace(query.URLOptions.Method) == "" {
-		query.URLOptions.Method = http.MethodGet
+		if m := strings.TrimSpace(settings.Method); m != "" {
+			query.URLOptions.Method = m
+		} else {
+			query.URLOptions.Method = http.MethodGet
+		}		
 	}
 	if query.Source == "url" && (!strings.EqualFold(query.URLOptions.Method, http.MethodGet)) {
 		if query.URLOptions.BodyType == "" {


### PR DESCRIPTION
When users define "method" at the top level of the query JSON (e.g. via button panels),
the plugin currently ignores it and always defaults to GET.

This patch adds a fallback to support "method" as a top-level field for backward compatibility.

Fixes #1173
