### PR TITLE
add custom value/label mapping in variable query editor

### DIFF
--- a/.changeset/silver-rings-grow.md
+++ b/.changeset/silver-rings-grow.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+add support for custom text value field mapping in variables

--- a/src/app/variablesQuery/index.ts
+++ b/src/app/variablesQuery/index.ts
@@ -13,7 +13,7 @@ import { JoinVariable } from '@/app/variablesQuery/Join';
 import { RandomVariable } from '@/app/variablesQuery/Random';
 import { UnixTimeStampVariable } from '@/app/variablesQuery/UnixTimeStamp';
 import { VariableEditor } from '@/editors/variable.editor';
-import type { VariableQuery, VariableQueryInfinity } from '@/types';
+import type { VariableQuery, VariableQueryInfinity, VariableMeta } from '@/types';
 
 export class InfinityVariableSupport extends CustomVariableSupport<Datasource, VariableQuery> {
   editor = VariableEditor;
@@ -67,7 +67,7 @@ export class InfinityVariableSupport extends CustomVariableSupport<Datasource, V
           map((d: DataQueryResponse) => {
             return {
               ...d,
-              data: d.data.map((frame: DataFrame) => ({ ...frame, fields: convertOriginalFieldsToVariableFields(frame.fields) })),
+              data: d.data.map((frame: DataFrame) => ({ ...frame, fields: convertOriginalFieldsToVariableFields(frame.fields, query.meta) })),
             };
           })
         );
@@ -87,10 +87,14 @@ export class InfinityVariableSupport extends CustomVariableSupport<Datasource, V
   }
 }
 
-export const convertOriginalFieldsToVariableFields = (original_fields: Array<Field<any>>): Array<Field<any>> => {
+export const convertOriginalFieldsToVariableFields = (original_fields: Array<Field<any>>, meta?: VariableMeta): Array<Field<any>> => {
   let fields: Field[] = [];
   let tf = original_fields.find((f) => f.name === '__text');
   let vf = original_fields.find((f) => f.name === '__value');
+  if (meta) {
+    tf = meta.textField ? original_fields.find((f) => f.name === meta.textField) : undefined;
+    vf = meta.valueField ? original_fields.find((f) => f.name === meta.valueField) : undefined;
+  }
   if (original_fields.length >= 2 && tf && vf) {
     fields = [
       { ...tf, name: 'text' },

--- a/src/editors/variable.editor.tsx
+++ b/src/editors/variable.editor.tsx
@@ -1,12 +1,17 @@
-import { TagsInput, TextArea, RadioButtonGroup, Field } from '@grafana/ui';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { DataFrame, SelectableValue, type DataQueryRequest } from '@grafana/data';
+import { TagsInput, TextArea, RadioButtonGroup, Field, Select } from '@grafana/ui';
+import { EditorRows, EditorRow } from '@/components/extended/EditorRow';
+import { EditorField } from '@/components/extended/EditorField';
 import { migrateLegacyQuery } from '@/app/variablesQuery';
 import { variableQueryTypes } from '@/constants';
 import { Datasource } from '@/datasource';
 import { InfinityQueryEditor } from '@/editors/query/infinityQuery';
-import type { InfinityQuery, VariableQuery, VariableQueryInfinity, VariableQueryLegacy, VariableQueryRandom, VariableQueryType } from '@/types';
+import type { InfinityQuery, VariableMeta, VariableQuery, VariableQueryInfinity, VariableQueryLegacy, VariableQueryRandom, VariableQueryType } from '@/types';
 
-export const VariableEditor = (props: { query: VariableQuery; onChange: (query: VariableQuery, definition: string) => void; datasource: Datasource }) => {
+type Props = { query: VariableQuery; onChange: (query: VariableQuery, definition: string) => void; datasource: Datasource };
+
+export const VariableEditor = (props: Props) => {
   const query = migrateLegacyQuery(props.query);
   const onQueryTypeChange = (queryType: VariableQueryType) => {
     const newQuery: VariableQuery = { ...query, queryType } as VariableQuery;
@@ -20,7 +25,61 @@ export const VariableEditor = (props: { query: VariableQuery; onChange: (query: 
       {query.queryType === 'infinity' && query.infinityQuery && <VariableEditorInfinity {...props} query={query} />}
       {query.queryType === 'legacy' && <VariableEditorLegacy {...props} query={query} />}
       {query.queryType === 'random' && <VariableEditorRandom {...props} query={query} />}
+      {query.queryType === 'infinity' && <FieldMapping {...props} />}
     </>
+  );
+};
+
+const FieldMapping = (props: Props) => {
+  const { query, datasource } = props;
+  const [choices, setChoices] = useState<SelectableValue[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  useEffect(() => {
+    if (query.queryType !== 'infinity' || !query.infinityQuery) {
+      setChoices([]);
+      setIsLoading(false);
+      return;
+    }
+    let isActive = true;
+    setIsLoading(true);
+    const target: InfinityQuery = { ...query.infinityQuery, refId: query.refId || query.infinityQuery.refId || 'field-mapping-query' };
+    const subscription = datasource.query({ targets: [target] } as DataQueryRequest<InfinityQuery>).subscribe({
+      next: (response) => {
+        if (!isActive) {
+          return;
+        }
+        const fieldNames = ((response.data[0] || { fields: [] }) as DataFrame).fields.map((f) => f.name);
+        setChoices(fieldNames.map((f) => ({ value: f, label: f })));
+        setIsLoading(false);
+      },
+      error: () => {
+        if (isActive) {
+          setChoices([]);
+          setIsLoading(false);
+        }
+      },
+    });
+    return () => {
+      isActive = false;
+      subscription.unsubscribe();
+    };
+  }, [datasource, query]);
+  const onMetaPropChange = <Key extends keyof VariableMeta, Value extends VariableMeta[Key]>(key: Key, value: Value, meta = query.meta || {}) => {
+    props.onChange({ ...query, meta: { ...meta, [key]: value } }, '');
+  };
+  return (
+    <EditorRows>
+      <EditorRow collapsible label="Custom field mapping" title={() => ''}>
+        <EditorField label="Value Field" horizontal tooltip="Field name that can be used as a value of the variable">
+          {/* eslint-disable-next-line */}
+          <Select isClearable value={query.meta?.valueField} onChange={(e) => onMetaPropChange('valueField', e?.value)} width={40} options={choices} isLoading={isLoading} />
+        </EditorField>
+        <EditorField label="Text Field" horizontal tooltip="Field name that can be used as a display value of the variable">
+          {/* eslint-disable-next-line */}
+          <Select isClearable value={query.meta?.textField} onChange={(e) => onMetaPropChange('textField', e?.value)} width={40} options={choices} isLoading={isLoading} />
+        </EditorField>
+      </EditorRow>
+    </EditorRows>
   );
 };
 

--- a/src/types/variables.types.ts
+++ b/src/types/variables.types.ts
@@ -1,9 +1,10 @@
 import type { InfinityQuery } from '@/types';
 
 //#region Variable Query
+export type VariableMeta = { valueField?: string; textField?: string };
 export type VariableTokenLegacy = 'Collection' | 'CollectionLookup' | 'Random' | 'Join' | 'UnixTimeStamp';
 export type VariableQueryType = 'legacy' | 'infinity' | 'random';
-export type VariableQueryBase<T extends VariableQueryType> = { queryType: T; refId: string };
+export type VariableQueryBase<T extends VariableQueryType> = { queryType: T; refId: string; meta?: VariableMeta };
 export type VariableQueryLegacy = { query: string; infinityQuery?: InfinityQuery } & VariableQueryBase<'legacy'>;
 export type VariableQueryInfinity = { infinityQuery: InfinityQuery; query?: string } & VariableQueryBase<'infinity'>;
 export type VariableQueryRandom = { values: string[] } & VariableQueryBase<'random'>;


### PR DESCRIPTION
## Before

Users have to manually alias the fields with `__text` or `__value` notation to mark them as the fields to use for value/text when used with variables. This is documented [here](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource/latest/variables/variables/).

<img width="825" height="776" alt="image" src="https://github.com/user-attachments/assets/c3e5b6af-17e7-4d47-9524-72a9efdb4cc5" />


## After

<img width="1221" height="884" alt="image" src="https://github.com/user-attachments/assets/16ca26da-40ac-497a-8de3-343861cf4149" />
<img width="1185" height="908" alt="image" src="https://github.com/user-attachments/assets/176c7d72-69a0-48eb-938e-b4d54e1f42d8" />
<img width="1514" height="882" alt="image" src="https://github.com/user-attachments/assets/6a8abed9-ba01-4aa2-b87e-8d29a39c6c22" />
<img width="1122" height="877" alt="image" src="https://github.com/user-attachments/assets/7e9fed86-99a0-4f33-8245-2a0cbf3a701a" />
