### PR TITLE
Add support for rfc9557 timestamp strings (#1382)

### DIFF
--- a/.changeset/eighty-frogs-wash.md
+++ b/.changeset/eighty-frogs-wash.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+Add support for rfc9557 timestamp strings (#1382)

--- a/pkg/infinity/csvBackend.go
+++ b/pkg/infinity/csvBackend.go
@@ -42,7 +42,7 @@ func GetCSVBackendResponse(ctx context.Context, responseString string, query mod
 	if query.Type == models.QueryTypeTSV {
 		csvOptions.Delimiter = "\t"
 	}
-	newFrame, err := csvframer.ToFrame(responseString, csvOptions)
+	newFrame, err := csvframer.ToFrame(stripRFC9557Timezone(responseString), csvOptions)
 	if newFrame != nil {
 		frame.Fields = append(frame.Fields, newFrame.Fields...)
 	}

--- a/pkg/infinity/inline.go
+++ b/pkg/infinity/inline.go
@@ -51,7 +51,7 @@ func GetFrameForInlineSources(ctx context.Context, query models.Query) (*data.Fr
 		if query.Parser == models.InfinityParserJQBackend {
 			framerOptions.FramerType = jsonframer.FramerTypeJQ
 		}
-		newFrame, err := jsonframer.ToFrame(query.Data, framerOptions)
+		newFrame, err := jsonframer.ToFrame(stripRFC9557Timezone(query.Data), framerOptions)
 		if err != nil {
 			if errors.Is(err, jsonframer.ErrInvalidRootSelector) || errors.Is(err, jsonframer.ErrInvalidJSONContent) || errors.Is(err, jsonframer.ErrEvaluatingJSONata) {
 				return frame, backend.DownstreamError(fmt.Errorf("error converting json data to frame: %w", err))

--- a/pkg/infinity/jsonBackend.go
+++ b/pkg/infinity/jsonBackend.go
@@ -42,7 +42,7 @@ func GetJSONBackendResponse(ctx context.Context, urlResponseObject any, query mo
 	if query.Parser == models.InfinityParserJQBackend {
 		framerOptions.FramerType = jsonframer.FramerTypeJQ
 	}
-	newFrame, err := jsonframer.ToFrame(string(responseString), framerOptions)
+	newFrame, err := jsonframer.ToFrame(stripRFC9557Timezone(string(responseString)), framerOptions)
 
 	if err != nil {
 		if errors.Is(err, jsonframer.ErrInvalidRootSelector) || errors.Is(err, jsonframer.ErrInvalidJSONContent) || errors.Is(err, jsonframer.ErrEvaluatingJSONata) {

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/grafana/grafana-infinity-datasource/pkg/models"
@@ -14,6 +15,12 @@ import (
 	"github.com/grafana/infinity-libs/lib/go/jsonframer"
 	"github.com/grafana/infinity-libs/lib/go/transformations"
 )
+
+var rfc9557Regex = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\[[^\]]+\]`)
+
+func stripRFC9557Timezone(input string) string {
+	return rfc9557Regex.ReplaceAllString(input, "$1")
+}
 
 func isBackendQuery(query models.Query) bool {
 	return query.Parser == models.InfinityParserBackend || query.Parser == models.InfinityParserJQBackend

--- a/pkg/infinity/remote_test.go
+++ b/pkg/infinity/remote_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStripRFC9557Timezone(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "2025-11-10T16:46:51+01:00[Europe/Paris]",
+			expected: "2025-11-10T16:46:51+01:00",
+		},
+		{
+			input:    "2025-11-10T16:46:51.123Z[UTC]",
+			expected: "2025-11-10T16:46:51.123Z",
+		},
+		{
+			input:    "Normal text [with brackets]",
+			expected: "Normal text [with brackets]",
+		},
+	}
+
+	for _, tt := range tests {
+		result := stripRFC9557Timezone(tt.input)
+		require.Equal(t, tt.expected, result)
+	}
+}
+
 func TestApplyPaginationItemToQuery(t *testing.T) {
 	t.Run(string(models.PaginationParamTypeQuery), func(t *testing.T) {
 		tests := []struct {

--- a/pkg/infinity/xmlBackend.go
+++ b/pkg/infinity/xmlBackend.go
@@ -33,7 +33,7 @@ func GetXMLBackendResponse(ctx context.Context, inputString string, query models
 	if query.Parser == models.InfinityParserJQBackend {
 		framerOptions.FramerType = string(jsonframer.FramerTypeJQ)
 	}
-	newFrame, err := xmlframer.ToFrame(inputString, framerOptions)
+	newFrame, err := xmlframer.ToFrame(stripRFC9557Timezone(inputString), framerOptions)
 	if newFrame != nil {
 		frame.Fields = append(frame.Fields, newFrame.Fields...)
 	}

--- a/src/app/parsers/utils.spec.ts
+++ b/src/app/parsers/utils.spec.ts
@@ -53,4 +53,8 @@ describe('utils', () => {
     expect(getValue('1609459200', 'timestamp_epoch_s')).toStrictEqual(new Date('2021'));
     expect(getValue(1609459200, 'timestamp_epoch_s')).toStrictEqual(new Date('2021'));
   });
+  it('RFC9557 support', () => {
+    expect(getValue('2025-11-10T16:46:51+01:00[Europe/Paris]', 'timestamp')).toStrictEqual(new Date('2025-11-10T16:46:51+01:00'));
+    expect(getValue('2025-11-10T16:46:51.123Z[UTC]', 'timestamp')).toStrictEqual(new Date('2025-11-10T16:46:51.123Z'));
+  });
 });

--- a/src/app/parsers/utils.ts
+++ b/src/app/parsers/utils.ts
@@ -54,6 +54,13 @@ export const columnarToTable = (response: any, columns: InfinityColumn[] = []) =
   return res;
 };
 
+export const stripRFC9557Timezone = (input: string): string => {
+  if (typeof input !== 'string') {
+    return input;
+  }
+  return input.replace(/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\[[^\]]+\]/g, '$1');
+};
+
 export const getValue = (input: string | boolean | number | Date | null, type: InfinityColumnFormat, asTimestamp?: boolean) => {
   switch (type) {
     case 'string':
@@ -85,7 +92,12 @@ export const getValue = (input: string | boolean | number | Date | null, type: I
         return null;
       }
     case 'timestamp':
-      return asTimestamp ? new Date(input + '').getTime() : new Date(input + '');
+      let dateString = input + '';
+      // RFC9557 support: strip timezone information in brackets if present
+      if (dateString.includes('[') && dateString.trim().endsWith(']')) {
+        dateString = dateString.split('[')[0];
+      }
+      return asTimestamp ? new Date(dateString + '').getTime() : new Date(dateString + '');
     case 'timestamp_epoch':
       if (typeof input === 'string') {
         return asTimestamp ? new Date(parseInt(input, 10)).getTime() : new Date(parseInt(input, 10));

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -12,6 +12,7 @@ import { AnnotationsEditor } from '@/editors/annotation.editor';
 import { interpolateQuery, interpolateVariableQuery } from '@/interpolate';
 import { migrateQuery } from '@/migrate';
 import { isBackendQuery } from '@/app/utils';
+import { stripRFC9557Timezone } from '@/app/parsers/utils';
 import type { InfinityInstanceSettings, InfinityOptions, InfinityQuery, MetricFindValue, VariableQuery } from '@/types';
 
 export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOptions> {
@@ -202,13 +203,13 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
             resolve(data);
           }
           if ((t.type === 'json' || t.type === 'csv' || t.type === 'tsv' || t.type === 'graphql' || t.type === 'xml') && t.parser === 'uql') {
-            applyUQL(t.uql || '', data, t.format, t.refId)
+            applyUQL(t.uql || '', stripRFC9557Timezone(data), t.format, t.refId)
               .then(resolve)
               .catch(reject);
             break;
           }
           if ((t.type === 'json' || t.type === 'graphql') && t.parser === 'groq') {
-            applyGroq(t.groq || '', data, t.format, t.refId)
+            applyGroq(t.groq || '', stripRFC9557Timezone(data), t.format, t.refId)
               .then(resolve)
               .catch(reject);
             break;
@@ -216,10 +217,10 @@ export class Datasource extends DataSourceWithBackend<InfinityQuery, InfinityOpt
           new InfinityProvider(t, this).formatResults(data).then(resolve).catch(reject);
           break;
         case 'uql':
-          applyUQL(t.uql, data, t.format, t.refId).then(resolve).catch(reject);
+          applyUQL(t.uql, stripRFC9557Timezone(data), t.format, t.refId).then(resolve).catch(reject);
           break;
         case 'groq':
-          applyGroq(t.groq, data, t.format, t.refId).then(resolve).catch(reject);
+          applyGroq(t.groq, stripRFC9557Timezone(data), t.format, t.refId).then(resolve).catch(reject);
           break;
         case 'series':
           new SeriesProvider(interpolateQuery(t, scopedVars)).query(new Date(range?.from?.toDate()).getTime(), new Date(range?.to?.toDate()).getTime()).then(resolve).catch(reject);


### PR DESCRIPTION
- Strip bracketed timezone information (e.g., [Europe/Paris]) before parsing.
- Supported in both frontend (JS) and backend (Go) parsers.
- Ensures compatibility with UQL, GROQ, and backend alerting.
- fix (#1382)