### PR TITLE
Chore: add PR read permission to publish gh action

### DIFF
--- a/.config/.cprc.json
+++ b/.config/.cprc.json
@@ -1,4 +1,4 @@
 {
-  "version": "6.7.5",
+  "version": "6.8.4",
   "features": {}
 }

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ permissions:
   attestations: write
   contents: write
   id-token: write
+  pull-requests: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Publish script is failing due to missing permission https://github.com/grafana/grafana-infinity-datasource/actions/runs/21862526046

Earlier the renovate PR https://github.com/grafana/grafana-infinity-datasource/pull/1509/changes updated the version but didn't added the permission related change.