### PR TITLE
Update links to OAuth2 Custom Tokens documentation

### DIFF
--- a/docs/sources/configure.md
+++ b/docs/sources/configure.md
@@ -158,7 +158,7 @@ OAuth 2.0 client credentials authentication requires the following settings:
 | **Scopes**          | Optional. Specifies requested permissions.                                            |
 | **Endpoint params** | Optional. Additional parameters for requests to the token endpoint.                   |
 
-For advanced token customization, refer to [OAuth2 Custom Tokens](/docs/plugins/yesoreyeram-infinity-datasource/latest/advanced-features/oauth2-custom-tokens/). Key customization options include:
+For advanced token customization, refer to [OAuth2 Custom Tokens](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource/latest/advanced-features/advanced-features/oauth2-custom-tokens/). Key customization options include:
 
 - Custom header names (for example, `X-API-Key` instead of `Authorization`)
 - Custom token value formats (for example, `Token ${__oauth2.access_token}` instead of `Bearer ${__oauth2.access_token}`)
@@ -177,7 +177,7 @@ OAuth 2.0 JWT authentication requires the following settings:
 | **Subject**                 | Optional. The user to impersonate.                                                      |
 | **Scopes**                  | Optional. A comma-separated list of requested permission scopes.                        |
 
-OAuth 2.0 JWT authentication also supports token customization. Refer to [OAuth2 Custom Tokens](/docs/plugins/yesoreyeram-infinity-datasource/latest/advanced-features/oauth2-custom-tokens/) for details.
+OAuth 2.0 JWT authentication also supports token customization. Refer to [OAuth2 Custom Tokens](https://grafana.com/docs/plugins/yesoreyeram-infinity-datasource/latest/advanced-features/advanced-features/oauth2-custom-tokens/) for details.
 
 #### Azure authentication
 


### PR DESCRIPTION
This PR fixes 2 broken links as reported in https://raintank-corp.slack.com/archives/C5PG2JK8W/p1777021545180049