### PR TITLE
fix: implement cursor pagination with JSON body (body_json)

### DIFF
--- a/.changeset/cursor-pagination-body-json.md
+++ b/.changeset/cursor-pagination-body-json.md
@@ -1,0 +1,5 @@
+---
+"grafana-infinity-datasource": patch
+---
+
+Fix cursor pagination for POST APIs that expect the next page token inside the JSON body. The `body_json` pagination param type is now implemented (cursor value is injected into the request JSON body), exposed in the query editor, and cursor pagination no longer errors when the final page omits the cursor field.

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -116,6 +116,19 @@ func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationP
 		query.URLOptions.Headers = append(query.URLOptions.Headers, field)
 	case models.PaginationParamTypeBodyData:
 		query.URLOptions.BodyForm = append(query.URLOptions.BodyForm, field)
+	case models.PaginationParamTypeBodyJson:
+		body := map[string]any{}
+		if trimmed := strings.TrimSpace(query.URLOptions.Body); trimmed != "" {
+			if err := json.Unmarshal([]byte(trimmed), &body); err != nil {
+				// Body isn't a valid JSON object; leave it untouched rather than
+				// overwriting the user's payload with just the cursor field.
+				return query
+			}
+		}
+		body[fieldName] = fieldValue
+		if b, err := json.Marshal(body); err == nil {
+			query.URLOptions.Body = string(b)
+		}
 	case models.PaginationParamTypeReplace:
 		fieldNameUpdated := fmt.Sprintf(`${__pagination.%s}`, fieldName)
 		query.URL = strings.ReplaceAll(query.URL, fieldNameUpdated, field.Value)
@@ -229,7 +242,11 @@ func GetFrameForURLSourcesWithPostProcessing(ctx context.Context, pCtx *backend.
 		}
 		cursor, err = jsonframer.GetRootData(string(body), query.PageParamCursorFieldExtractionPath, framerType)
 		if err != nil {
-			return frame, cursor, backend.PluginError(errors.New("error while extracting the cursor value"))
+			// Many cursor-based APIs omit the cursor field entirely on the last
+			// page (instead of returning an empty value). In that case the
+			// extraction yields no result, which we treat as "no more pages"
+			// rather than a fatal error so pagination stops gracefully.
+			return frame, "", nil
 		}
 	}
 	return frame, cursor, nil

--- a/pkg/infinity/remote_test.go
+++ b/pkg/infinity/remote_test.go
@@ -99,14 +99,42 @@ func TestApplyPaginationItemToQuery(t *testing.T) {
 		}
 	})
 	t.Run(string(models.PaginationParamTypeBodyJson), func(t *testing.T) {
-		t.Skip() // TODO: NOT IMPLEMENTED YET
 		tests := []struct {
 			name       string
 			query      models.Query
 			fieldName  string
 			fieldValue string
 			want       models.Query
-		}{}
+		}{
+			{
+				name:       "should inject pagination cursor into empty body",
+				query:      models.Query{URLOptions: models.URLOptions{Body: ""}},
+				fieldName:  "nextPageToken",
+				fieldValue: "abc123",
+				want:       models.Query{URLOptions: models.URLOptions{Body: `{"nextPageToken":"abc123"}`}},
+			},
+			{
+				name:       "should inject pagination cursor into existing JSON body",
+				query:      models.Query{URLOptions: models.URLOptions{Body: `{"filter":"active"}`}},
+				fieldName:  "nextPageToken",
+				fieldValue: "page2",
+				want:       models.Query{URLOptions: models.URLOptions{Body: `{"filter":"active","nextPageToken":"page2"}`}},
+			},
+			{
+				name:       "should overwrite existing cursor key in JSON body",
+				query:      models.Query{URLOptions: models.URLOptions{Body: `{"nextPageToken":"old","filter":"active"}`}},
+				fieldName:  "nextPageToken",
+				fieldValue: "new",
+				want:       models.Query{URLOptions: models.URLOptions{Body: `{"filter":"active","nextPageToken":"new"}`}},
+			},
+			{
+				name:       "should not overwrite a non-JSON body",
+				query:      models.Query{URLOptions: models.URLOptions{Body: `not a json body`}},
+				fieldName:  "nextPageToken",
+				fieldValue: "abc123",
+				want:       models.Query{URLOptions: models.URLOptions{Body: `not a json body`}},
+			},
+		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				got := ApplyPaginationItemToQuery(tt.query, models.PaginationParamTypeBodyJson, tt.fieldName, tt.fieldValue)

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -53,7 +53,7 @@ const (
 	PaginationParamTypeQuery    PaginationParamType = "query"
 	PaginationParamTypeHeader   PaginationParamType = "header"
 	PaginationParamTypeBodyData PaginationParamType = "body_data"
-	PaginationParamTypeBodyJson PaginationParamType = "body_json" // TODO: NOT IMPLEMENTED YET
+	PaginationParamTypeBodyJson PaginationParamType = "body_json"
 	PaginationParamTypeReplace  PaginationParamType = "replace"
 )
 

--- a/src/editors/query/query.pagination.tsx
+++ b/src/editors/query/query.pagination.tsx
@@ -17,7 +17,7 @@ const paginationParamTypes: Array<ComboboxOption<PaginationParamType>> = [
   { value: 'query', label: 'Query param' },
   { value: 'header', label: 'Header' },
   { value: 'body_data', label: 'Body form' },
-  // { value: 'body_json', label: 'Body JSON' },
+  { value: 'body_json', label: 'Body JSON' },
   { value: 'replace', label: 'Replace URL' },
 ];
 


### PR DESCRIPTION
## Problem

When paginating a POST API with cursor pagination where the `nextPageToken` cursor must be sent inside the JSON request body, Infinity always returned the first page. The `body_json` pagination param type was declared in the models but never implemented — the cursor was appended as a query parameter instead of being injected into the body, so every request was identical.

## Changes

- Implement the `body_json` pagination param type in `ApplyPaginationItemToQuery`: the cursor key/value is merged into the request JSON body (guarded so a non-JSON body is left untouched rather than overwritten).
- Expose the "Body JSON" option in the pagination param type dropdown in the query editor (it was commented out).
- Handle the final page gracefully: many cursor APIs omit the cursor field on the last page, which previously caused `error while extracting the cursor value` and failed the whole query. This is now treated as "no more pages".

## Testing

- Added unit tests for `body_json` injection (empty body, existing body, overwrite existing key, non-JSON body left untouched).
- `go test ./...`, `go vet`, `yarn typecheck`, `yarn lint`, `yarn test:ci` and `yarn spellcheck` all pass.
- Verified end-to-end against a real POST API (Jira `/rest/api/3/search/jql`) paginating 3500+ records via `nextPageToken` in the JSON body.