### PR TITLE
chore: drop dev-preview-react19 from E2E matrix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,4 +35,5 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: true
       run-playwright-with-skip-grafana-dev-image: true
+      run-playwright-with-skip-grafana-react-19-preview-image: true
       github-draft-release: false

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,4 +16,5 @@ jobs:
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright-with-skip-grafana-dev-image: true
+      run-playwright-with-skip-grafana-react-19-preview-image: true
       run-playwright: true


### PR DESCRIPTION
## Summary

- Removes the `dev-preview-react19` Grafana image from the Playwright E2E matrix by setting `run-playwright-with-skip-grafana-react-19-preview-image: true`
- The dev-preview image was flaky (CI failure in run [#26819355710](https://github.com/grafana/grafana-infinity-datasource/actions/runs/26819355710/job/80281877999): Grafana never started, status 000 throughout the health check)

## Test plan

- [x] CI passes without the `dev-preview-react19` matrix entry
- [x] Grafana 13 E2E job still runs and passes