### PR TITLE
Add `defaultSemverRangePrefix`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.13.0.cjs
 
 enableScripts: false
+
+defaultSemverRangePrefix: ""


### PR DESCRIPTION
When someone runs yarn add some-new-package, Yarn's built-in default is to prefix the version with ^. Without it, a developer adding a dependency manually would silently introduce a semver range, undoing the pinning discipline. This PR closes the gap.