### PR TITLE
Add generic backend pagination support for GraphQL cursors

### DIFF
--- a/.changeset/metal-dots-smoke.md
+++ b/.changeset/metal-dots-smoke.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Add generic backend pagination support for GraphQL/JSON/CSV/TSV/XML/HTML URL queries, including cursor pagination improvements for GraphQL (`replace` first-page handling, `hasNextPage`-aware stopping), plus stronger retry and boundary behavior.

--- a/pkg/infinity/pagination_test.go
+++ b/pkg/infinity/pagination_test.go
@@ -2,7 +2,9 @@ package infinity
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -208,5 +210,75 @@ func TestGetPaginatedResultsCursorHonorsMaxPagesBoundary(t *testing.T) {
 
 	mu.Lock()
 	assert.Equal(t, 5, requests)
+	mu.Unlock()
+}
+
+func TestGetPaginatedResultsGraphQLCursorReplaceStartsWithNullAndStopsOnHasNextPageFalse(t *testing.T) {
+	type graphQLRequest struct {
+		Variables map[string]any `json:"variables"`
+	}
+	var (
+		mu                sync.Mutex
+		requests          int
+		firstAfterValue   any
+		secondAfterValue  any
+		thirdRequestCount int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		req := graphQLRequest{}
+		_ = json.Unmarshal(body, &req)
+		after := req.Variables["after"]
+
+		mu.Lock()
+		requests++
+		switch requests {
+		case 1:
+			firstAfterValue = after
+		case 2:
+			secondAfterValue = after
+		case 3:
+			thirdRequestCount++
+		}
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			_, _ = w.Write([]byte(`{"data":{"search":{"edges":[{"node":{"id":1}}],"pageInfo":{"hasNextPage":true,"endCursor":"c1"}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"search":{"edges":[{"node":{"id":2}}],"pageInfo":{"hasNextPage":false,"endCursor":"c2"}}}}`))
+	}))
+	defer server.Close()
+
+	query := models.Query{
+		Type:   models.QueryTypeGraphQL,
+		Source: "url",
+		Parser: models.InfinityParserBackend,
+		URL:    server.URL,
+		URLOptions: models.URLOptions{
+			Method:               http.MethodPost,
+			BodyType:             "graphql",
+			BodyGraphQLQuery:     `query($q: String!, $first: Int!, $after: String) { search(query: $q, type: REPOSITORY, first: $first, after: $after) { edges { node { id } } pageInfo { hasNextPage endCursor } } }`,
+			BodyGraphQLVariables: `{ "q":"org:grafana", "first": 1, "after":"${__pagination.cursor}" }`,
+		},
+		RootSelector:                       "data.search.edges",
+		Columns:                            []models.InfinityColumn{{Text: "id", Selector: "node.id", Type: "number"}},
+		PageMode:                           models.PaginationModeCursor,
+		PageMaxPages:                       10,
+		PageParamCursorFieldType:           models.PaginationParamTypeReplace,
+		PageParamCursorFieldName:           "cursor",
+		PageParamCursorFieldExtractionPath: "data.search.pageInfo.endCursor",
+	}
+	client := Client{Settings: models.InfinitySettings{}, HttpClient: server.Client(), IsMock: true}
+	frame, err := GetPaginatedResults(context.Background(), nil, query, client, map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+
+	mu.Lock()
+	require.Equal(t, 2, requests)
+	require.Nil(t, firstAfterValue)
+	require.Equal(t, "c1", secondAfterValue)
+	require.Equal(t, 0, thirdRequestCount)
 	mu.Unlock()
 }

--- a/pkg/infinity/pagination_test.go
+++ b/pkg/infinity/pagination_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestGetPaginatedResultsCursorStopsWhenCursorEnds(t *testing.T) {
+	// Verifies cursor pagination stops as soon as extracted endCursor becomes empty.
 	var (
 		mu       sync.Mutex
 		requests int
@@ -65,6 +66,7 @@ func TestGetPaginatedResultsCursorStopsWhenCursorEnds(t *testing.T) {
 }
 
 func TestGetPaginatedResultsPageModeRetriesAndSucceeds(t *testing.T) {
+	// Verifies per-page retries recover from transient failures and continue pagination.
 	var (
 		mu          sync.Mutex
 		page2Errors int
@@ -121,6 +123,7 @@ func TestGetPaginatedResultsPageModeRetriesAndSucceeds(t *testing.T) {
 }
 
 func TestGetPaginatedResultsPageModeFailsAfterRetryExhaustion(t *testing.T) {
+	// Verifies query fails fast when a page keeps failing after all retry attempts.
 	var (
 		mu          sync.Mutex
 		page2Errors int
@@ -176,6 +179,7 @@ func TestGetPaginatedResultsPageModeFailsAfterRetryExhaustion(t *testing.T) {
 }
 
 func TestGetPaginatedResultsCursorHonorsMaxPagesBoundary(t *testing.T) {
+	// Verifies cursor mode never exceeds pagination_max_pages.
 	var (
 		mu       sync.Mutex
 		requests int
@@ -214,6 +218,7 @@ func TestGetPaginatedResultsCursorHonorsMaxPagesBoundary(t *testing.T) {
 }
 
 func TestGetPaginatedResultsGraphQLCursorReplaceStartsWithNullAndStopsOnHasNextPageFalse(t *testing.T) {
+	// Verifies GraphQL replace-mode sends null cursor on first request and stops when hasNextPage=false.
 	type graphQLRequest struct {
 		Variables map[string]any `json:"variables"`
 	}

--- a/pkg/infinity/pagination_test.go
+++ b/pkg/infinity/pagination_test.go
@@ -1,0 +1,212 @@
+package infinity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafana-infinity-datasource/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPaginatedResultsCursorStopsWhenCursorEnds(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		cursor := r.URL.Query().Get("cursor")
+		w.Header().Set("Content-Type", "application/json")
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{"data":{"items":[{"id":1}],"pageInfo":{"endCursor":"c1"}}}`))
+		case "c1":
+			_, _ = w.Write([]byte(`{"data":{"items":[{"id":2}],"pageInfo":{"endCursor":"c2"}}}`))
+		case "c2":
+			_, _ = w.Write([]byte(`{"data":{"items":[{"id":3}],"pageInfo":{"endCursor":""}}}`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unexpected cursor"}`))
+		}
+	}))
+	defer server.Close()
+
+	query := models.Query{
+		Type:                               models.QueryTypeGraphQL,
+		Source:                             "url",
+		Parser:                             models.InfinityParserBackend,
+		URL:                                server.URL,
+		RootSelector:                       "data.items",
+		Columns:                            []models.InfinityColumn{{Text: "id", Selector: "id", Type: "number"}},
+		PageMode:                           models.PaginationModeCursor,
+		PageMaxPages:                       10,
+		PageParamCursorFieldType:           models.PaginationParamTypeQuery,
+		PageParamCursorFieldName:           "cursor",
+		PageParamCursorFieldExtractionPath: "data.pageInfo.endCursor",
+	}
+	client := Client{Settings: models.InfinitySettings{}, HttpClient: server.Client(), IsMock: true}
+	frame, err := GetPaginatedResults(context.Background(), nil, query, client, map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+
+	mu.Lock()
+	assert.Equal(t, 3, requests)
+	mu.Unlock()
+}
+
+func TestGetPaginatedResultsPageModeRetriesAndSucceeds(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		page2Errors int
+		requests    int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		page := r.URL.Query().Get("page")
+		if page == "2" {
+			mu.Lock()
+			page2Errors++
+			shouldFail := page2Errors <= pageRequestRetries
+			mu.Unlock()
+			if shouldFail {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":"temporary"}`))
+				return
+			}
+		}
+		pageNo, _ := strconv.Atoi(page)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"items":[{"id":%d}]}`, pageNo)))
+	}))
+	defer server.Close()
+
+	query := models.Query{
+		Type:                   models.QueryTypeJSON,
+		Source:                 "url",
+		Parser:                 models.InfinityParserBackend,
+		URL:                    server.URL,
+		URLOptions:             models.URLOptions{Method: http.MethodGet},
+		RootSelector:           "items",
+		Columns:                []models.InfinityColumn{{Text: "id", Selector: "id", Type: "number"}},
+		PageMode:               models.PaginationModePage,
+		PageMaxPages:           3,
+		PageParamSizeFieldType: models.PaginationParamTypeQuery,
+		PageParamSizeFieldName: "limit",
+		PageParamSizeFieldVal:  1,
+		PageParamPageFieldType: models.PaginationParamTypeQuery,
+		PageParamPageFieldName: "page",
+		PageParamPageFieldVal:  1,
+	}
+	client := Client{Settings: models.InfinitySettings{}, HttpClient: server.Client(), IsMock: true}
+	frame, err := GetPaginatedResults(context.Background(), nil, query, client, map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+
+	mu.Lock()
+	assert.Equal(t, 3, page2Errors)
+	assert.Equal(t, 5, requests)
+	mu.Unlock()
+}
+
+func TestGetPaginatedResultsPageModeFailsAfterRetryExhaustion(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		page2Errors int
+		page3Calls  int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "2" {
+			mu.Lock()
+			page2Errors++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"permanent"}`))
+			return
+		}
+		if page == "3" {
+			mu.Lock()
+			page3Calls++
+			mu.Unlock()
+		}
+		pageNo, _ := strconv.Atoi(page)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"items":[{"id":%d}]}`, pageNo)))
+	}))
+	defer server.Close()
+
+	query := models.Query{
+		Type:                   models.QueryTypeJSON,
+		Source:                 "url",
+		Parser:                 models.InfinityParserBackend,
+		URL:                    server.URL,
+		URLOptions:             models.URLOptions{Method: http.MethodGet},
+		RootSelector:           "items",
+		Columns:                []models.InfinityColumn{{Text: "id", Selector: "id", Type: "number"}},
+		PageMode:               models.PaginationModePage,
+		PageMaxPages:           3,
+		PageParamSizeFieldType: models.PaginationParamTypeQuery,
+		PageParamSizeFieldName: "limit",
+		PageParamSizeFieldVal:  1,
+		PageParamPageFieldType: models.PaginationParamTypeQuery,
+		PageParamPageFieldName: "page",
+		PageParamPageFieldVal:  1,
+	}
+	client := Client{Settings: models.InfinitySettings{}, HttpClient: server.Client(), IsMock: true}
+	frame, err := GetPaginatedResults(context.Background(), nil, query, client, map[string]string{})
+	require.Error(t, err)
+	require.Nil(t, frame)
+
+	mu.Lock()
+	assert.Equal(t, pageRequestRetries+1, page2Errors)
+	assert.Equal(t, 0, page3Calls)
+	mu.Unlock()
+}
+
+func TestGetPaginatedResultsCursorHonorsMaxPagesBoundary(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		next := fmt.Sprintf("c%d", requests)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"items":[{"id":1}],"pageInfo":{"endCursor":"%s"}}}`, next)))
+	}))
+	defer server.Close()
+
+	query := models.Query{
+		Type:                               models.QueryTypeGraphQL,
+		Source:                             "url",
+		Parser:                             models.InfinityParserBackend,
+		URL:                                server.URL,
+		RootSelector:                       "data.items",
+		Columns:                            []models.InfinityColumn{{Text: "id", Selector: "id", Type: "number"}},
+		PageMode:                           models.PaginationModeCursor,
+		PageMaxPages:                       5,
+		PageParamCursorFieldType:           models.PaginationParamTypeQuery,
+		PageParamCursorFieldName:           "cursor",
+		PageParamCursorFieldExtractionPath: "data.pageInfo.endCursor",
+	}
+	client := Client{Settings: models.InfinitySettings{}, HttpClient: server.Client(), IsMock: true}
+	frame, err := GetPaginatedResults(context.Background(), nil, query, client, map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+
+	mu.Lock()
+	assert.Equal(t, 5, requests)
+	mu.Unlock()
+}

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -19,10 +19,29 @@ func isBackendQuery(query models.Query) bool {
 	return query.Parser == models.InfinityParserBackend || query.Parser == models.InfinityParserJQBackend
 }
 
+func canPaginateQuery(query models.Query) bool {
+	if !isBackendQuery(query) || query.PageMode == "" || query.PageMode == models.PaginationModeNone {
+		return false
+	}
+	switch query.PageMode {
+	case models.PaginationModeCursor:
+		return query.Type == models.QueryTypeJSON || query.Type == models.QueryTypeGraphQL
+	case models.PaginationModeOffset, models.PaginationModePage, models.PaginationModeList:
+		return query.Type == models.QueryTypeJSON ||
+			query.Type == models.QueryTypeGraphQL ||
+			query.Type == models.QueryTypeCSV ||
+			query.Type == models.QueryTypeTSV ||
+			query.Type == models.QueryTypeXML ||
+			query.Type == models.QueryTypeHTML
+	default:
+		return false
+	}
+}
+
 func GetFrameForURLSources(ctx context.Context, pCtx *backend.PluginContext, query models.Query, infClient Client, requestHeaders map[string]string) (*data.Frame, error) {
 	ctx, span := tracing.DefaultTracer().Start(ctx, "GetFrameForURLSources")
 	defer span.End()
-	if query.Type == models.QueryTypeJSON && isBackendQuery(query) && query.PageMode != models.PaginationModeNone && query.PageMode != "" {
+	if canPaginateQuery(query) {
 		return GetPaginatedResults(ctx, pCtx, query, infClient, requestHeaders)
 	}
 	frame, _, err := GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, query, infClient, requestHeaders, true)

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -19,6 +19,8 @@ func isBackendQuery(query models.Query) bool {
 	return query.Parser == models.InfinityParserBackend || query.Parser == models.InfinityParserJQBackend
 }
 
+const pageRequestRetries = 2
+
 func canPaginateQuery(query models.Query) bool {
 	if !isBackendQuery(query) || query.PageMode == "" || query.PageMode == models.PaginationModeNone {
 		return false
@@ -53,7 +55,6 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 	defer span.End()
 	frames := []*data.Frame{}
 	queries := []models.Query{}
-	var errs error
 	switch query.PageMode {
 	case models.PaginationModeOffset:
 		for pageNumber := 1; pageNumber <= query.PageMaxPages; pageNumber++ {
@@ -92,37 +93,51 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 	}
 	if query.PageMode != models.PaginationModeCursor {
 		for _, currentQuery := range queries {
-			frame, _, err := GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
+			frame, _, err := GetFrameForURLSourcesWithRetries(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
+			if err != nil {
+				return nil, err
+			}
 			frames = append(frames, frame)
-			errs = errors.Join(errs, err)
 		}
 	}
 	if query.PageMode == models.PaginationModeCursor {
-		i := 0
 		oCursor := ""
-		for {
+		for pageNumber := 0; pageNumber < query.PageMaxPages; pageNumber++ {
 			currentQuery := query
-			if i > 0 && oCursor != "" {
+			if pageNumber > 0 {
+				if oCursor == "" {
+					break
+				}
 				currentQuery = ApplyPaginationItemToQuery(currentQuery, query.PageParamCursorFieldType, query.PageParamCursorFieldName, oCursor)
 			}
-			if i > query.PageMaxPages || (i > 0 && oCursor == "") {
-				break
+			frame, cursor, err := GetFrameForURLSourcesWithRetries(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
+			if err != nil {
+				return nil, err
 			}
-			i++
-			frame, cursor, err := GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
 			oCursor = cursor
 			frames = append(frames, frame)
-			errs = errors.Join(errs, err)
 		}
-	}
-	if errs != nil {
-		return nil, errs
 	}
 	mergedFrame, err := transformations.Merge(frames, transformations.MergeFramesOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return PostProcessFrame(ctx, mergedFrame, query)
+}
+
+func GetFrameForURLSourcesWithRetries(ctx context.Context, pCtx *backend.PluginContext, query models.Query, infClient Client, requestHeaders map[string]string, postProcessingRequired bool) (*data.Frame, string, error) {
+	var (
+		frame  *data.Frame
+		cursor string
+		err    error
+	)
+	for attempt := 0; attempt <= pageRequestRetries; attempt++ {
+		frame, cursor, err = GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, query, infClient, requestHeaders, postProcessingRequired)
+		if err == nil {
+			return frame, cursor, nil
+		}
+	}
+	return frame, cursor, err
 }
 
 func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationParamType, fieldName string, fieldValue string) models.Query {

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -22,6 +22,7 @@ func isBackendQuery(query models.Query) bool {
 const pageRequestRetries = 2
 
 func canPaginateQuery(query models.Query) bool {
+	// Keep pagination generic: allow any backend-parsed URL query type that our backend framers support.
 	if !isBackendQuery(query) || query.PageMode == "" || query.PageMode == models.PaginationModeNone {
 		return false
 	}
@@ -104,6 +105,7 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 		oCursor := ""
 		for pageNumber := 0; pageNumber < query.PageMaxPages; pageNumber++ {
 			currentQuery := query
+			// For replace-mode GraphQL cursors, page 1 should send null instead of a literal macro token.
 			if pageNumber == 0 && query.PageParamCursorFieldType == models.PaginationParamTypeReplace {
 				currentQuery = ApplyPaginationItemToQuery(currentQuery, query.PageParamCursorFieldType, query.PageParamCursorFieldName, "")
 			}
@@ -135,6 +137,7 @@ func GetFrameForURLSourcesWithRetries(ctx context.Context, pCtx *backend.PluginC
 		err    error
 	)
 	for attempt := 0; attempt <= pageRequestRetries; attempt++ {
+		// Retry each page independently; on final failure we return the last page error.
 		frame, cursor, err = GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, query, infClient, requestHeaders, postProcessingRequired)
 		if err == nil {
 			return frame, cursor, nil
@@ -159,6 +162,7 @@ func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationP
 	case models.PaginationParamTypeReplace:
 		fieldNameUpdated := fmt.Sprintf(`${__pagination.%s}`, fieldName)
 		if fieldValue == "" {
+			// Replace quoted placeholder with JSON null to keep GraphQL variables payload valid.
 			quotedToken := fmt.Sprintf(`"%s"`, fieldNameUpdated)
 			query.URLOptions.BodyGraphQLVariables = strings.ReplaceAll(query.URLOptions.BodyGraphQLVariables, quotedToken, "null")
 		}
@@ -277,6 +281,7 @@ func GetFrameForURLSourcesWithPostProcessing(ctx context.Context, pCtx *backend.
 		}
 		hasNextPath := strings.TrimSuffix(query.PageParamCursorFieldExtractionPath, ".endCursor")
 		if hasNextPath != query.PageParamCursorFieldExtractionPath {
+			// If the payload exposes pageInfo.hasNextPage alongside endCursor, respect it as an explicit stop signal.
 			hasNextValue, hasNextErr := jsonframer.GetRootData(string(body), hasNextPath+".hasNextPage", framerType)
 			if hasNextErr == nil && strings.EqualFold(strings.TrimSpace(hasNextValue), "false") {
 				cursor = ""

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -104,6 +104,9 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 		oCursor := ""
 		for pageNumber := 0; pageNumber < query.PageMaxPages; pageNumber++ {
 			currentQuery := query
+			if pageNumber == 0 && query.PageParamCursorFieldType == models.PaginationParamTypeReplace {
+				currentQuery = ApplyPaginationItemToQuery(currentQuery, query.PageParamCursorFieldType, query.PageParamCursorFieldName, "")
+			}
 			if pageNumber > 0 {
 				if oCursor == "" {
 					break
@@ -141,7 +144,10 @@ func GetFrameForURLSourcesWithRetries(ctx context.Context, pCtx *backend.PluginC
 }
 
 func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationParamType, fieldName string, fieldValue string) models.Query {
-	if strings.TrimSpace(fieldValue) == "" {
+	if strings.TrimSpace(fieldName) == "" {
+		return query
+	}
+	if strings.TrimSpace(fieldValue) == "" && fieldType != models.PaginationParamTypeReplace {
 		return query
 	}
 	field := models.URLOptionKeyValuePair{Key: fieldName, Value: fieldValue}
@@ -152,6 +158,10 @@ func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationP
 		query.URLOptions.BodyForm = append(query.URLOptions.BodyForm, field)
 	case models.PaginationParamTypeReplace:
 		fieldNameUpdated := fmt.Sprintf(`${__pagination.%s}`, fieldName)
+		if fieldValue == "" {
+			quotedToken := fmt.Sprintf(`"%s"`, fieldNameUpdated)
+			query.URLOptions.BodyGraphQLVariables = strings.ReplaceAll(query.URLOptions.BodyGraphQLVariables, quotedToken, "null")
+		}
 		query.URL = strings.ReplaceAll(query.URL, fieldNameUpdated, field.Value)
 		query.URLOptions.Body = strings.ReplaceAll(query.URLOptions.Body, fieldNameUpdated, field.Value)
 		query.URLOptions.BodyGraphQLQuery = strings.ReplaceAll(query.URLOptions.BodyGraphQLQuery, fieldNameUpdated, fieldValue)
@@ -264,6 +274,13 @@ func GetFrameForURLSourcesWithPostProcessing(ctx context.Context, pCtx *backend.
 		cursor, err = jsonframer.GetRootData(string(body), query.PageParamCursorFieldExtractionPath, framerType)
 		if err != nil {
 			return frame, cursor, backend.PluginError(errors.New("error while extracting the cursor value"))
+		}
+		hasNextPath := strings.TrimSuffix(query.PageParamCursorFieldExtractionPath, ".endCursor")
+		if hasNextPath != query.PageParamCursorFieldExtractionPath {
+			hasNextValue, hasNextErr := jsonframer.GetRootData(string(body), hasNextPath+".hasNextPage", framerType)
+			if hasNextErr == nil && strings.EqualFold(strings.TrimSpace(hasNextValue), "false") {
+				cursor = ""
+			}
 		}
 	}
 	return frame, cursor, nil

--- a/pkg/infinity/remote_test.go
+++ b/pkg/infinity/remote_test.go
@@ -278,6 +278,11 @@ func TestApplyPaginationItemToQuery(t *testing.T) {
 					require.Equal(t, tt.want, got)
 				})
 			}
+			t.Run("should replace quoted graphql cursor token with null when field value is empty", func(t *testing.T) {
+				query := models.Query{URLOptions: models.URLOptions{BodyGraphQLVariables: `{ "after" : "${__pagination.cursor}" }`}}
+				got := ApplyPaginationItemToQuery(query, models.PaginationParamTypeReplace, "cursor", "")
+				require.Equal(t, `{ "after" : null }`, got.URLOptions.BodyGraphQLVariables)
+			})
 		})
 		t.Run("replace params in URL Headers", func(t *testing.T) {
 			tests := []struct {

--- a/pkg/infinity/remote_test.go
+++ b/pkg/infinity/remote_test.go
@@ -7,6 +7,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCanPaginateQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		query models.Query
+		want  bool
+	}{
+		{
+			name:  "supports graphql page mode for backend parser",
+			query: models.Query{Type: models.QueryTypeGraphQL, Parser: models.InfinityParserBackend, PageMode: models.PaginationModePage},
+			want:  true,
+		},
+		{
+			name:  "supports csv list mode for jq-backend parser",
+			query: models.Query{Type: models.QueryTypeCSV, Parser: models.InfinityParserJQBackend, PageMode: models.PaginationModeList},
+			want:  true,
+		},
+		{
+			name:  "supports graphql cursor mode for jq-backend parser",
+			query: models.Query{Type: models.QueryTypeGraphQL, Parser: models.InfinityParserJQBackend, PageMode: models.PaginationModeCursor},
+			want:  true,
+		},
+		{
+			name:  "does not support csv cursor mode",
+			query: models.Query{Type: models.QueryTypeCSV, Parser: models.InfinityParserBackend, PageMode: models.PaginationModeCursor},
+			want:  false,
+		},
+		{
+			name:  "does not support pagination for simple parser",
+			query: models.Query{Type: models.QueryTypeJSON, Parser: models.InfinityParserSimple, PageMode: models.PaginationModePage},
+			want:  false,
+		},
+		{
+			name:  "does not support pagination with none page mode",
+			query: models.Query{Type: models.QueryTypeJSON, Parser: models.InfinityParserBackend, PageMode: models.PaginationModeNone},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, canPaginateQuery(tt.query))
+		})
+	}
+}
+
 func TestApplyPaginationItemToQuery(t *testing.T) {
 	t.Run(string(models.PaginationParamTypeQuery), func(t *testing.T) {
 		tests := []struct {

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -254,7 +254,7 @@ func ApplyDefaultsToQuery(ctx context.Context, pCtx *backend.PluginContext, quer
 	if query.ComputedColumns == nil {
 		query.ComputedColumns = []InfinityColumn{}
 	}
-	if query.Parser == InfinityParserBackend && query.Source == "url" && query.PageMode != "" && query.PageMode != PaginationModeNone {
+	if (query.Parser == InfinityParserBackend || query.Parser == InfinityParserJQBackend) && query.Source == "url" && query.PageMode != "" && query.PageMode != PaginationModeNone {
 		if query.PageMode != PaginationModeNone {
 			query.PageMaxPages = GetPaginationMaxPagesValue(ctx, pCtx, query)
 			if query.PageParamSizeFieldName == "" {

--- a/pkg/models/query_test.go
+++ b/pkg/models/query_test.go
@@ -180,3 +180,22 @@ func TestGetPaginationMaxPagesValue(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyDefaultsToQueryAppliesPaginationDefaultsForJQBackend(t *testing.T) {
+	query := models.Query{
+		Parser:       models.InfinityParserJQBackend,
+		Source:       "url",
+		PageMode:     models.PaginationModePage,
+		PageMaxPages: 100,
+	}
+
+	got := models.ApplyDefaultsToQuery(context.Background(), nil, query, models.InfinitySettings{})
+
+	require.Equal(t, 5, got.PageMaxPages)
+	require.Equal(t, "limit", got.PageParamSizeFieldName)
+	require.Equal(t, models.PaginationParamTypeQuery, got.PageParamSizeFieldType)
+	require.Equal(t, 1000, got.PageParamSizeFieldVal)
+	require.Equal(t, "page", got.PageParamPageFieldName)
+	require.Equal(t, models.PaginationParamTypeQuery, got.PageParamPageFieldType)
+	require.Equal(t, 1, got.PageParamPageFieldVal)
+}

--- a/src/editors/query/infinityQuery.test.tsx
+++ b/src/editors/query/infinityQuery.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { EditorMode, InfinityQuery, InfinityQueryFormat } from '@/types';
 import { InfinityEditorProps, InfinityQueryEditor } from '@/editors/query/infinityQuery';
 import { Datasource } from '@/datasource';
@@ -66,5 +66,51 @@ describe('InfinityQueryEditor', () => {
 
     expect(mockOnChange).not.toHaveBeenCalled();
     expect(mockOnRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('shows pagination editor for graphql backend URL queries', () => {
+    const query = {
+      refId: 'A',
+      type: 'graphql',
+      parser: 'backend',
+      source: 'url',
+      url: 'https://api.github.com/graphql',
+      root_selector: 'data.search.edges',
+      format: 'table',
+    } as InfinityQuery;
+    const props: InfinityEditorProps = {
+      query,
+      onChange: mockOnChange,
+      onRunQuery: mockOnRunQuery,
+      instanceSettings: { jsonData: {} },
+      mode: 'standard' as EditorMode,
+      datasource: {} as Datasource,
+    };
+
+    render(<InfinityQueryEditor {...props} />);
+    expect(screen.getByText('Pagination')).toBeInTheDocument();
+  });
+
+  it('does not show pagination editor for non-backend graphql queries', () => {
+    const query = {
+      refId: 'A',
+      type: 'graphql',
+      parser: 'simple',
+      source: 'url',
+      url: 'https://api.github.com/graphql',
+      root_selector: 'data.search.edges',
+      format: 'table',
+    } as InfinityQuery;
+    const props: InfinityEditorProps = {
+      query,
+      onChange: mockOnChange,
+      onRunQuery: mockOnRunQuery,
+      instanceSettings: { jsonData: {} },
+      mode: 'standard' as EditorMode,
+      datasource: {} as Datasource,
+    };
+
+    render(<InfinityQueryEditor {...props} />);
+    expect(screen.queryByText('Pagination')).not.toBeInTheDocument();
   });
 });

--- a/src/editors/query/infinityQuery.tsx
+++ b/src/editors/query/infinityQuery.tsx
@@ -59,6 +59,10 @@ export const InfinityQueryEditor = (props: InfinityEditorProps) => {
     query.type !== 'groq' &&
     query.columns &&
     query.columns.length > 0;
+  const canShowPaginationEditor =
+    query.source === 'url' &&
+    ['json', 'graphql', 'csv', 'tsv', 'xml', 'html'].includes(query.type) &&
+    (query.parser === 'backend' || query.parser === 'jq-backend');
   return (
     <div className="infinity-query-editor" data-testid="infinity-query-editor" style={{ marginBottom: '5px' }}>
       <EditorRows>
@@ -94,9 +98,7 @@ export const InfinityQueryEditor = (props: InfinityEditorProps) => {
         )}
         {(query.type === 'json' || query.type === 'graphql' || query.type === 'csv' || query.type === 'tsv' || query.type === 'xml') &&
           (query.parser === 'backend' || query.parser === 'jq-backend') && <ExperimentalFeatures query={query} onChange={onChange} onRunQuery={onRunQuery} />}
-        {query.type === 'json' && (query.parser === 'backend' || query.parser === 'jq-backend') && query.source === 'url' && (
-          <PaginationEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />
-        )}
+        {canShowPaginationEditor && <PaginationEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />}
         {query.type === 'transformations' && <TransformationsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />}
         <QueryWarning query={query} />
       </EditorRows>


### PR DESCRIPTION
## Why
GitHub GraphQL cursor pagination was failing in real usage, and pagination handling was effectively limited to narrower backend query paths. This change makes pagination support generic across backend URL query types while fixing cursor-specific behavior needed for GraphQL providers.

## What changed
- Generalized backend pagination eligibility beyond JSON-only flows to support backend/jq-backend URL queries for JSON, GraphQL, CSV, TSV, XML, and HTML (cursor mode remains JSON/GraphQL).
- Hardened pagination execution:
  - Added per-page retry behavior (2 retries per page).
  - Fixed cursor loop boundary behavior.
  - Fail the whole query when a page exhausts retries.
- Fixed parser defaults so pagination defaults are applied for both `backend` and `jq-backend`.
- Enabled pagination editor UI for eligible backend URL query types, including GraphQL.
- Fixed GraphQL replace-mode cursor behavior:
  - First page replaces quoted `${__pagination.cursor}` with `null`.
  - Stops pagination when `hasNextPage=false` when available with `endCursor` path.
- Added a changeset for release notes.
- Added concise inline comments in `remote.go` for non-obvious pagination behavior and test descriptions in `pagination_test.go`.

## Tests
- `go test ./pkg/...`
- `go test ./pkg/infinity ./pkg/models`
- `yarn test:ci src/editors/query/infinityQuery.test.tsx`
- Added/updated focused coverage in:
  - `pkg/infinity/remote_test.go`
  - `pkg/infinity/pagination_test.go`
  - `pkg/models/query_test.go`
  - `src/editors/query/infinityQuery.test.tsx`

## Notes for reviewers
The key review surface is `pkg/infinity/remote.go` cursor flow, especially first-page replace handling and stop conditions using both `endCursor` and `hasNextPage` semantics.