### PR TITLE
rename skill files

### DIFF
--- a/.changeset/little-camels-take.md
+++ b/.changeset/little-camels-take.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': minor
----
-
-Renames skill files to make it more easy to discover them via agents

--- a/.changeset/little-camels-take.md
+++ b/.changeset/little-camels-take.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': minor
+---
+
+Renames skill files to make it more easy to discover them via agents

--- a/.changeset/plenty-brooms-argue.md
+++ b/.changeset/plenty-brooms-argue.md
@@ -1,5 +1,0 @@
----
-'grafana-infinity-datasource': patch
----
-
-Chore: remove unused dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 3.9.0
+
+### Minor Changes
+
+🚀 Renames skill files to make it more easy to discover them via agents
+
+### Patch Changes
+
+⚙️ Chore: remove unused dependencies
+
 ## 3.8.1
 
 🚀 add dsconfig schema, apiserver schema, configuration and querying skills

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-infinity-datasource",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "description": "JSON, CSV, XML, GraphQL, HTML and REST API datasource for Grafana. Do infinite things with Grafana. Transform data with UQL/GROQ. Visualize data from many apis, RSS/ATOM feeds directly",
   "keywords": [
     "grafana",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-infinity-datasource",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "JSON, CSV, XML, GraphQL, HTML and REST API datasource for Grafana. Do infinite things with Grafana. Transform data with UQL/GROQ. Visualize data from many apis, RSS/ATOM feeds directly",
   "keywords": [
     "grafana",

--- a/skills/configuring-yesoreyeram-infinity-datasource/SKILL.md
+++ b/skills/configuring-yesoreyeram-infinity-datasource/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: configuring-infinity-datasource
+name: configuring-yesoreyeram-infinity-datasource
 description: Configure the Infinity data source — base URL and allowed hosts, the authentication methods (basic, bearer token, API key, digest, OAuth passthrough, OAuth 2.0 client credentials/JWT, Azure, Azure Blob, AWS), TLS, custom HTTP headers, network and security settings, the custom health check, and provisioning with a config file. Use when a user asks how to set up, configure, or change settings for the Infinity data source; how to authenticate to an API; how to allow hosts; how to provision it as YAML; or how to troubleshoot connection, authentication, or health-check issues.
 ---
 
@@ -584,5 +584,5 @@ below.
 
 ## See also
 
-- `querying-infinity-datasource` — build queries, choose types/parsers/sources, and
+- `querying-yesoreyeram-infinity-datasource` — build queries, choose types/parsers/sources, and
   shape results into data frames.

--- a/skills/querying-yesoreyeram-infinity-datasource/SKILL.md
+++ b/skills/querying-yesoreyeram-infinity-datasource/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: querying-infinity-datasource
+name: querying-yesoreyeram-infinity-datasource
 description: Build queries with the Infinity data source — the query types (JSON, CSV, TSV, XML, GraphQL, HTML, UQL, GROQ, Google Sheets, Series, Transformations), the parsers (Frontend/simple, Backend JSONata, JQ, UQL, GROQ) and which support alerting, the sources (URL, Inline, Reference, Azure Blob, Random walk), output formats (table, timeseries, logs, trace, node graph, dataframe), root selector and columns, computed columns/filters/summarize, pagination, and template variables. Use when a user asks how to query Infinity; how to fetch JSON/CSV/XML/GraphQL/HTML from a URL or inline; how to select rows and columns; how to transform data with UQL/GROQ/JSONata/JQ; how to make a query work with alerting; how to paginate; or how to use variables in a query.
 ---
 
@@ -186,5 +186,5 @@ that query an API for dropdown values. See
 
 ## See also
 
-- `configuring-infinity-datasource` — set up the data source, authentication, allowed
+- `configuring-yesoreyeram-infinity-datasource` — set up the data source, authentication, allowed
   hosts, TLS, network settings, the health check, and provisioning.


### PR DESCRIPTION
Renames skill files to configuring-<plugin_type> and querying-<plugin_type> so that I is easier to parametrize for agents when fetching resources across multiple datasources