### PR TITLE
docs: add signed commits requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing
 
+## Signed commits are required
+
+> [!IMPORTANT]
+> All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (GPG, SSH, or S/MIME) to be merged into this repository. Pull requests with unsigned commits will need to be re-committed with signatures before they can be merged.
+
+
 If you want to contribute to the plugin, you can contribute in one of the following ways
 
 - [Test different APIs](https://github.com/grafana/grafana-infinity-datasource/discussions/categories/specific-apis) and create bugs if not working as expected


### PR DESCRIPTION
## Summary

- Adds a highly visible callout at the top of `CONTRIBUTING.md` stating that signed commits (GPG, SSH, or S/MIME) are required to merge into this repository, per the recent policy change
- Uses GitHub's `[!IMPORTANT]` alert syntax so it renders as a highlighted callout, and links to GitHub's signed-commits docs.

## Checks

- `prettier --check CONTRIBUTING.md` passes.
