### PR TITLE
fix(variable-editor): skip unnamed fields when building field mapping options

### DIFF
--- a/.changeset/fix-variable-editor-unnamed-field-crash.md
+++ b/.changeset/fix-variable-editor-unnamed-field-crash.md
@@ -1,0 +1,5 @@
+---
+"grafana-infinity-datasource": patch
+---
+
+Fix variable editor crash when the query returns a field without a name, such as when adding a new column with an empty selector while using the JSONata or JQ backend parsers

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -120,6 +120,7 @@
     "notequals",
     "notin",
     "offcanvas",
+    "omitempty",
     "openfeature",
     "openissues",
     "openpr",

--- a/src/editors/variable.editor.test.tsx
+++ b/src/editors/variable.editor.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FieldType, type DataFrame } from '@grafana/data';
+import { of } from 'rxjs';
+import { VariableEditor } from '@/editors/variable.editor';
+import type { Datasource } from '@/datasource';
+import type { VariableQuery } from '@/types';
+
+// Mock react-router-dom Link component
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+// Mock @grafana/ui Link component to avoid Router context issues
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+describe('VariableEditor', () => {
+  const query: VariableQuery = {
+    refId: 'A',
+    queryType: 'infinity',
+    infinityQuery: {
+      refId: 'A',
+      type: 'json',
+      source: 'inline',
+      parser: 'backend',
+      data: '{}',
+      root_selector: '',
+      columns: [{ text: '', selector: '', type: 'string' }],
+      filters: [],
+      format: 'table',
+    },
+  } as VariableQuery;
+
+  const mockOnChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not crash the field mapping editor when the query returns a field without a name', async () => {
+    // Backend parser queries with an empty column selector return a frame whose
+    // field name is omitted on the wire (json omitempty), so it arrives as undefined
+    const frame: DataFrame = {
+      fields: [{ name: undefined as unknown as string, type: FieldType.string, values: [null], config: {} }],
+      length: 1,
+    };
+    const datasource = {
+      name: 'Infinity',
+      instanceSettings: { jsonData: {} },
+      query: () => of({ data: [frame] }),
+    } as unknown as Datasource;
+
+    render(<VariableEditor query={query} onChange={mockOnChange} datasource={datasource} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Value Field')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/editors/variable.editor.tsx
+++ b/src/editors/variable.editor.tsx
@@ -48,7 +48,11 @@ const FieldMapping = (props: Props) => {
         if (!isActive) {
           return;
         }
-        const fieldNames = ((response.data[0] || { fields: [] }) as DataFrame).fields.map((f) => f.name);
+        // Backend parser queries with unnamed columns yield fields whose name is omitted
+        // on the wire, and Combobox options must have a defined value
+        const fieldNames = ((response.data[0] || { fields: [] }) as DataFrame).fields
+          .map((f) => f.name)
+          .filter((name): name is string => typeof name === 'string' && name !== '');
         setChoices(fieldNames.map((f) => ({ value: f, label: f })));
         setIsLoading(false);
       },


### PR DESCRIPTION
## What

The variable editor crashed with a full-page "An unexpected error happened" (`TypeError: Cannot read properties of undefined (reading 'toString')`) when the variable query returned a data frame containing a field without a name. The most common trigger is clicking "Add Columns" under "Parsing options & Result fields" with the JSONata or JQ backend parsers: the newly added column has an empty selector, the backend returns a frame whose only field has an empty name, the SDK omits empty names from the wire format (`json:"name,omitempty"`), and the field arrives in the frontend as `name: undefined`.

The "Custom field mapping" section builds Combobox options from those field names, and the `@grafana/ui` Combobox throws when an option has neither `label` nor `value`. This is a regression from the Select to Combobox migration (#1545, first shipped in v3.7.2), as Select tolerated undefined option values.

## Fix

Filter out unnamed and empty-named fields before building the Value Field / Text Field combobox options in the variable editor.

**User-facing impact**: clicking "Add Columns" in a variable query using the JSONata/JQ backend parsers no longer crashes the page, and dashboards whose variable query already contains a column with an empty selector no longer crash the variable editor on open.

Internal escalation: https://github.com/grafana/support-escalations/issues/23172