### PR TITLE
fix(build): externalise react/jsx-runtime to match host react version

### DIFF
--- a/.changeset/fix-externalise-react-jsx-runtime.md
+++ b/.changeset/fix-externalise-react-jsx-runtime.md
@@ -1,0 +1,5 @@
+---
+"grafana-infinity-datasource": patch
+---
+
+Externalise `react/jsx-runtime` and `react/jsx-dev-runtime` so the host Grafana provides a version-matched JSX runtime, preventing plugin load failures on Grafana 13.x (React 19) when a bundled dependency imports `react/jsx-runtime`

--- a/.config/bundler/externals.ts
+++ b/.config/bundler/externals.ts
@@ -16,6 +16,8 @@ export const externals: ExternalsType = [
   'slate-plain-serializer',
   '@grafana/slate-react',
   'react',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
   'react-dom',
   'react-redux',
   'redux',


### PR DESCRIPTION
## What

Adds `react/jsx-runtime` and `react/jsx-dev-runtime` to the webpack externals, matching the current `@grafana/create-plugin` externals template, plus a patch changeset.

## Why

Webpack string externals only match exact requests, so externalising `react` does not cover the `react/jsx-runtime` subpath. When any bundled dependency is compiled with the automatic JSX runtime, webpack silently bundles React 18's `react-jsx-runtime.production.min.js`, which at module scope reads `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner` from the host `react` external. React 19 removed that internals object, so on Grafana 13.x (which runs plugins under React 19) the plugin fails at module evaluation with "Could not load plugin".

This is exactly why the E2E jobs on #1758 fail on the 13.0.4 and 13.1.1 matrix rows only: that PR bumps `@grafana/assistant` to 0.1.30, which (unlike 0.1.24) imports `react/jsx-runtime`. This change unblocks #1758, which should go green after merging `main` into it.

## Verification

Reproduced the #1758 failure locally against grafana-enterprise 13.1.1 (`TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')` via `System.import` of `module.js`). With this change and the #1758 dependency bumps applied together:

- the previously failing `smoke.spec.ts` and `configeditor.spec.ts` pass against 13.1.1 locally
- the config editor renders correctly on 11.6.16 (oldest version in the E2E matrix)
- `dist/module.js` no longer contains React 18 secret-internals references

On `main` as it stands this change is inert: nothing currently imports `react/jsx-runtime`, so the built module's SystemJS dependencies are unchanged.

## User-facing impact and caveat for reviewers

None today. Once a dependency that imports `react/jsx-runtime` lands (for example the `@grafana/assistant` bump in #1758), the plugin will require a Grafana build that exposes `react/jsx-runtime` to plugins (grafana/grafana#108478, backported to 11.6.11, 12.0.10, 12.1.7 and 12.2.5). On older patch releases within the declared `grafanaDependency: ">=11.6.0-0"` range the plugin would fail to load with a SystemJS 404 (verified on 12.2.4). It might be worth bumping `grafanaDependency` to `>=11.6.11` when that happens, or deciding that stale patch releases are out of support.