### PR TITLE
fix(security): bump jsonata to 1.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "webpack-virtual-modules": "0.6.2"
   },
   "resolutions": {
-    "fast-xml-parser": "5.7.0"
+    "fast-xml-parser": "5.7.0",
+    "jsonata@npm:1.8.7": "1.8.9"
   },
   "packageManager": "yarn@4.13.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9617,10 +9617,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonata@npm:1.8.7":
-  version: 1.8.7
-  resolution: "jsonata@npm:1.8.7"
-  checksum: 10c0/e18138fff369347075a0ab0f19bfb3bf20718a1b2731c8ad5343f680dc013b9bf4e7d27721822c19c006711402f1df476d6fecce627da058f87b05eee805f5b8
+"jsonata@npm:1.8.9":
+  version: 1.8.9
+  resolution: "jsonata@npm:1.8.9"
+  checksum: 10c0/82a1d30d102e9f0abdab8f430846bae4e4126a45456470cbe045f98383ad6aa9606c3052ce4a9e47cf06df01a7411df58290dc57e520a7e9c8f046d5e0c7ca39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Pin `jsonata` 1.8.7 -> 1.8.9 via selective resolution (CVE-2026-52746, HIGH, SLO deadline in 2 days)
- `uql` pins jsonata exactly, so an in-range update could not reach it; other near-SLO deps left for a later pass
- Checks: `yarn typecheck`, `yarn test:ci` (37 suites, 153 tests, 34 snapshots passed)