### PR TITLE
chore: prepare release 3.11.3

### DIFF
--- a/.changeset/fix-externalise-react-jsx-runtime.md
+++ b/.changeset/fix-externalise-react-jsx-runtime.md
@@ -1,5 +1,0 @@
----
-"grafana-infinity-datasource": patch
----
-
-Externalise `react/jsx-runtime` and `react/jsx-dev-runtime` so the host Grafana provides a version-matched JSX runtime, preventing plugin load failures on Grafana 13.x (React 19) when a bundled dependency imports `react/jsx-runtime`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 3.11.3
+
+### Patch Changes
+
+🐛 Security: bump `jsonata` from 1.8.7 to 1.8.9 (CVE-2026-52746)
+
 ## 3.11.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-infinity-datasource",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "JSON, CSV, XML, GraphQL, HTML and REST API datasource for Grafana. Do infinite things with Grafana. Transform data with UQL/GROQ. Visualize data from many apis, RSS/ATOM feeds directly",
   "keywords": [
     "grafana",


### PR DESCRIPTION
- Bump version to `3.11.3` via `yarn changeset version` (changelog generated from changesets)
- Adds the missing changeset for the `jsonata` 1.8.7 -> 1.8.9 security bump (CVE-2026-52746)
- Removes the stale `fix-externalise-react-jsx-runtime` changeset already shipped in v3.11.2