### PR TITLE
Fix pagination: handle empty pages and stop fetching past the last page

### DIFF
--- a/.changeset/fix-pagination-empty-pages.md
+++ b/.changeset/fix-pagination-empty-pages.md
@@ -1,0 +1,5 @@
+---
+'grafana-infinity-datasource': patch
+---
+
+Fix paginated queries failing with a merge error when a page returns an empty result, and stop fetching further pages once an empty or short page is received

--- a/pkg/infinity/pagination_test.go
+++ b/pkg/infinity/pagination_test.go
@@ -1,0 +1,123 @@
+package infinity_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/grafana-infinity-datasource/pkg/infinity"
+	"github.com/grafana/grafana-infinity-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+// newPaginationServer serves a JSON body keyed by the value of the given
+// query parameter. Unknown values return an empty array.
+func newPaginationServer(t *testing.T, key string, pages map[string]string, hits *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		body, ok := pages[r.URL.Query().Get(key)]
+		if !ok {
+			body = "[]"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+}
+
+func newPaginationQuery(url string) models.Query {
+	return models.Query{
+		Type:                   models.QueryTypeJSON,
+		Source:                 "url",
+		Parser:                 models.InfinityParserBackend,
+		URL:                    url,
+		PageMaxPages:           5,
+		PageParamSizeFieldName: "limit",
+		PageParamSizeFieldType: models.PaginationParamTypeQuery,
+		PageParamSizeFieldVal:  2,
+	}
+}
+
+func getPaginatedRows(t *testing.T, q models.Query, srv *httptest.Server) (int, error) {
+	t.Helper()
+	client := infinity.Client{Settings: models.InfinitySettings{}, HttpClient: srv.Client()}
+	frame, err := infinity.GetPaginatedResults(context.Background(), &backend.PluginContext{}, q, client, nil)
+	if err != nil {
+		return 0, err
+	}
+	return frame.Rows(), nil
+}
+
+func TestGetPaginatedResults_EmptyAndShortPages(t *testing.T) {
+	t.Run("offset mode stops after a page shorter than the page size", func(t *testing.T) {
+		var hits int32
+		srv := newPaginationServer(t, "offset", map[string]string{
+			"0": `[{"id":1},{"id":2}]`,
+			"2": `[{"id":3}]`,
+			"4": `[{"id":99}]`, // must never be requested
+		}, &hits)
+		defer srv.Close()
+		q := newPaginationQuery(srv.URL)
+		q.PageMode = models.PaginationModeOffset
+		q.PageParamOffsetFieldName = "offset"
+		q.PageParamOffsetFieldType = models.PaginationParamTypeQuery
+		rows, err := getPaginatedRows(t, q, srv)
+		require.NoError(t, err)
+		require.Equal(t, 3, rows)
+		require.Equal(t, int32(2), hits)
+	})
+	t.Run("offset mode drops an empty page after data and stops fetching", func(t *testing.T) {
+		var hits int32
+		srv := newPaginationServer(t, "offset", map[string]string{
+			"0": `[{"id":1},{"id":2}]`,
+			"2": `[{"id":3},{"id":4}]`,
+			// offset 4 returns []
+			"6": `[{"id":99}]`, // must never be requested
+		}, &hits)
+		defer srv.Close()
+		q := newPaginationQuery(srv.URL)
+		q.PageMode = models.PaginationModeOffset
+		q.PageParamOffsetFieldName = "offset"
+		q.PageParamOffsetFieldType = models.PaginationParamTypeQuery
+		rows, err := getPaginatedRows(t, q, srv)
+		require.NoError(t, err)
+		require.Equal(t, 4, rows)
+		require.Equal(t, int32(3), hits)
+	})
+	t.Run("page mode returns an empty result without error when the first page is empty", func(t *testing.T) {
+		var hits int32
+		srv := newPaginationServer(t, "page", map[string]string{}, &hits)
+		defer srv.Close()
+		q := newPaginationQuery(srv.URL)
+		q.PageMode = models.PaginationModePage
+		q.PageParamPageFieldName = "page"
+		q.PageParamPageFieldType = models.PaginationParamTypeQuery
+		rows, err := getPaginatedRows(t, q, srv)
+		require.NoError(t, err)
+		require.Equal(t, 0, rows)
+		require.Equal(t, int32(1), hits)
+	})
+	t.Run("cursor mode drops an empty page after data and stops fetching", func(t *testing.T) {
+		var hits int32
+		srv := newPaginationServer(t, "cursor", map[string]string{
+			"":    `{"next":"abc","items":[{"id":1},{"id":2}]}`,
+			"abc": `{"next":"def","items":[]}`,
+			"def": `{"next":"","items":[{"id":99}]}`, // must never be requested
+		}, &hits)
+		defer srv.Close()
+		q := newPaginationQuery(srv.URL)
+		q.PageMode = models.PaginationModeCursor
+		q.PageParamCursorFieldName = "cursor"
+		q.PageParamCursorFieldType = models.PaginationParamTypeQuery
+		q.PageParamCursorFieldExtractionPath = "next"
+		q.RootSelector = "items"
+		rows, err := getPaginatedRows(t, q, srv)
+		require.NoError(t, err)
+		require.Equal(t, 2, rows)
+		require.Equal(t, int32(2), hits)
+	})
+}

--- a/pkg/infinity/remote.go
+++ b/pkg/infinity/remote.go
@@ -74,8 +74,26 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 	if query.PageMode != models.PaginationModeCursor {
 		for _, currentQuery := range queries {
 			frame, _, err := GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
-			frames = append(frames, frame)
 			errs = errors.Join(errs, err)
+			if err != nil {
+				continue
+			}
+			if isEmptyPage(frame) {
+				// An empty page carries no fields and would break the merge.
+				// Keep it only if it is the very first page (so the query still
+				// returns an empty result), otherwise drop it and stop fetching:
+				// nothing after an empty page can have data.
+				if len(frames) == 0 {
+					frames = append(frames, frame)
+				}
+				break
+			}
+			frames = append(frames, frame)
+			// In offset/page mode a page shorter than the requested size is the
+			// last page, so there's no point requesting the following ones.
+			if isSizedPageMode(query.PageMode) && query.PageParamSizeFieldVal > 0 && frame.Rows() < query.PageParamSizeFieldVal {
+				break
+			}
 		}
 	}
 	if query.PageMode == models.PaginationModeCursor {
@@ -92,8 +110,17 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 			i++
 			frame, cursor, err := GetFrameForURLSourcesWithPostProcessing(ctx, pCtx, currentQuery, infClient, requestHeaders, false)
 			oCursor = cursor
-			frames = append(frames, frame)
 			errs = errors.Join(errs, err)
+			if err != nil {
+				continue
+			}
+			if isEmptyPage(frame) {
+				if len(frames) == 0 {
+					frames = append(frames, frame)
+				}
+				break
+			}
+			frames = append(frames, frame)
 		}
 	}
 	if errs != nil {
@@ -104,6 +131,19 @@ func GetPaginatedResults(ctx context.Context, pCtx *backend.PluginContext, query
 		return nil, err
 	}
 	return PostProcessFrame(ctx, mergedFrame, query)
+}
+
+// isEmptyPage reports whether a paginated response produced no usable frame.
+// The JSON framer returns a frame with zero fields for an empty array, which
+// the merge step rejects as "different fields".
+func isEmptyPage(frame *data.Frame) bool {
+	return frame == nil || len(frame.Fields) == 0 || frame.Rows() == 0
+}
+
+// isSizedPageMode reports whether the pagination mode carries a page size we
+// can compare against the number of rows returned.
+func isSizedPageMode(mode models.PaginationMode) bool {
+	return mode == models.PaginationModeOffset || mode == models.PaginationModePage
 }
 
 func ApplyPaginationItemToQuery(query models.Query, fieldType models.PaginationParamType, fieldName string, fieldValue string) models.Query {


### PR DESCRIPTION
## Fix pagination: handle empty pages and stop fetching past the last page

### Problem
Paginated JSON queries (offset, page, cursor) fail with a `different fields` merge error when any page returns an empty result. The JSON framer produces a frame with zero fields for `[]`, which the merge step rejects. The plugin also keeps requesting pages after the data has run out.

### Fix
- Drop empty pages before merging. If the very first page is empty, return an empty result instead of an error.
- Stop fetching after an empty page, since nothing after it can have data.
- In offset and page mode, stop after a page shorter than the requested page size.
- Pages that returned an error are no longer appended to the merge input.

### Tests
Added `pkg/infinity/pagination_test.go` covering offset, page and cursor modes against a local mock server. Each case asserts the merged row count and the exact number of HTTP requests made. All four cases fail on `main` and pass with this change.

### Changeset
Patch bump added.

---
This change was AI assisted.